### PR TITLE
virtme: support virtio-fs

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -99,6 +99,16 @@ _GENERIC_CONFIG = [
 
     '# Enable overlayfs',
     'CONFIG_OVERLAY_FS=y',
+
+    '# virtio-fs support',
+    'CONFIG_DAX=y',
+    'CONFIG_DAX_DRIVER=y',
+    'CONFIG_FS_DAX=y',
+    'CONFIG_MEMORY_HOTPLUG=y',
+    'CONFIG_MEMORY_HOTREMOVE=y',
+    'CONFIG_ZONE_DEVICE=y',
+    'CONFIG_FUSE_FS=y',
+    'CONFIG_VIRTIO_FS=y',
 ]
 
 _GENERIC_CONFIG_OPTIONAL = [

--- a/virtme/mkinitramfs.py
+++ b/virtme/mkinitramfs.py
@@ -77,10 +77,12 @@ source /modules/load_all.sh
 
 log 'mounting hostfs...'
 
-if ! /bin/mount -n -t 9p -o {access},version=9p2000.L,trans=virtio,access=any /dev/root /newroot/; then
-  echo "Failed to mount real root.  We are stuck."
-  sleep 5
-  exit 1
+if ! /bin/mount -n -t virtiofs ROOTFS /newroot/ 2>/dev/null; then
+  if ! /bin/mount -n -t 9p -o {access},version=9p2000.L,trans=virtio,access=any /dev/root /newroot/; then
+    echo "Failed to mount real root.  We are stuck."
+    sleep 5
+    exit 1
+  fi
 fi
 
 # Can we actually use /newroot/ as root?

--- a/virtme/virtmods.py
+++ b/virtme/virtmods.py
@@ -8,6 +8,7 @@
 MODALIASES = [
     # These are most likely portable across all architectures.
     'fs-9p',
+    'fs-virtiofs',
     'virtio:d00000009v00001AF4',  # 9pnet_virtio
     'virtio:d00000003v00001AF4',  # virtio_console
 


### PR DESCRIPTION
Virtiofs is a shared file system that lets virtual machines access a directory tree on the host. Unlike existing approaches, it is designed to offer local file system semantics and performance [1].

Compared to the 9P filesystem, virtio-fs offers consistent performance advantages by delivering access times that closely approach the native performance of the host filesystem.

Test case:
 - Run `git diff` from a linux git repo

Results:
       9p-fs: 283.814s
   virtio-fs:   1.174s

Speed up in this particular case is approximately 241.96 times faster.

Virtme will try to automatically enable the new virtio-fs support: if virtiofsd is found in the $PATH or in /usr/libexec, it'll be used to export the host's rootfs and qemu options will be automatically adjusted to use it. Otherwise virtme will fall-back to the legacy 9p-fs mode.

Moreover, introduce the new virtme-run option --force-9p to force the legacy 9p-fs mode, even when a proper virtiofsd is detected in the system.

Notes:

 - need to rely on the new Rust implementation of virtiofsd [2], instead of the daemon shipped in qemu, because the latter doesn't support unprivileged mode execution and it would be totally unsafe to export the whole rootfs of the host running as virtiofsd as root.

 - At the moment the Rust's virtiofsd doesn't seem to handle fs permissions correctly if used together with overlayfs [3], for this reason we need to apply a special patch to virtiofsd [4]. With this patch applied we can correctly export the entire root filesystem of the host inside the virtme guest and enable the full copy-on-write mode everywhere using overlayfs and tmpfs (maintaining the same behavior of the legacy 9p fs case).

[1] https://virtio-fs.gitlab.io/
[2] https://gitlab.com/virtio-fs/virtiofsd
[3] https://gitlab.com/virtio-fs/virtiofsd/-/issues/99
[4] https://github.com/arighi/virtiofsd/commit/8c72edfce01e9f5415bf1b963ec4e70042e22231