### PR TITLE
run.py: Fix get_kernel_version by checking for "Version" string

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -188,7 +188,7 @@ def get_kernel_version(path):
     if not os.access(path, os.R_OK):
         arg_fail("unable to access %s (check for read permissions)" % path, show_usage=False)
     result = subprocess.run(['file', path], capture_output=True, text=True)
-    match = re.search(r'version (\S+)', result.stdout)
+    match = re.search(r'[vV]ersion (\S+)', result.stdout)
     if match:
         kernel_version = match.group(1)
         return kernel_version


### PR DESCRIPTION
In my local kernel build, the output of "file bzImage" shows Version, instead of the expected version string:

$ file arch/x86/boot/bzImage
arch/x86/boot/bzImage: Linux/x86 Kernel, Setup Version 0x20f, bzImage, Version 6.4.0-rc3+ ...

So this fix makes virtme-run to work on current openSUSE Tumbleweed.