### PR TITLE
virtme-ng: allow to run graphical applications

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -48,6 +48,10 @@ class Arch(object):
         return ['-vga', 'none', '-display', 'none']
 
     @staticmethod
+    def qemu_display_args() -> List[str]:
+        return ['-device', 'virtio-gpu-pci']
+
+    @staticmethod
     def qemu_serial_console_args() -> List[str]:
         # We should be using the new-style -device serialdev,chardev=xyz,
         # but many architecture-specific serial devices don't support that.
@@ -172,6 +176,10 @@ class Arch_arm(Arch):
         # out how to find the dtb file.
 
         return ret
+
+    @staticmethod
+    def qemu_display_args() -> List[str]:
+        return ['-device', 'virtio-gpu-device']
 
     @staticmethod
     def virtio_dev_type(virtiotype):
@@ -333,6 +341,10 @@ class Arch_s390x(Arch):
         ret.extend(['-nodefaults'])
 
         return ret
+
+    @staticmethod
+    def qemu_display_args() -> List[str]:
+        return ['-device', 'virtio-gpu-ccw,devno=fe.0.0101']
 
     @staticmethod
     def config_base():

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -134,6 +134,11 @@ _GENERIC_CONFIG_OPTIONAL = [
     'CONFIG_DEBUG_FS=y',
     'CONFIG_PROVE_LOCKING=y',
 
+    '# Graphics support',
+    'CONFIG_DRM=y',
+    'CONFIG_DRM_VIRTIO_GPU=y',
+    'CONFIG_DRM_VIRTIO_GPU_KMS=y',
+
     '# Unnecessary configs',
     '# CONFIG_LOCALVERSION_AUTO is not set',
     '# CONFIG_TEST_KMOD is not set',
@@ -191,7 +196,6 @@ _GENERIC_CONFIG_OPTIONAL = [
     '# CONFIG_FB_MATROX is not set',
     '# CONFIG_FB_RADEON is not set',
     '# CONFIG_FB_IBM_GXT4500 is not set',
-    '# CONFIG_DRM is not set',
     '# CONFIG_FB_VESA is not set',
     '# CONFIG_YENTA is not set',
     '# CONFIG_NETFILTER is not set',

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -292,6 +292,21 @@ if [[ -n "${virtme_stty_con}" ]]; then
     # Program the console sensibly
     stty ${virtme_stty_con} <"/dev/$consdev"
 fi
+if [[ -n "${virtme_graphics}" ]]; then
+    # Create a .xinitrc to start the requested graphical application.
+    xinit_rc=/tmp/.xinitrc
+    echo "exec ${virtme_graphics}" > ${xinit_rc}
+    if [[ -n "${virtme_user}" ]]; then
+        chown ${virtme_user}:${virtme_user} ${xinit_rc}
+	# Try to fix permissions on the virtual consoles (udev could mess up
+	# permissions).
+	chmod a+rw /dev/tty*
+        setsid bash -c "su ${virtme_user} -c 'xinit ${xinit_rc}'" 0<>"/dev/$consdev" 1>&0 2>&0
+    else
+        setsid bash -c "xinit ${xinit_rc}" 0<>"/dev/$consdev" 1>&0 2>&0
+    fi
+    # Drop to console if the graphical app failed.
+fi
 if [[ -n "${virtme_user}" ]]; then
     setsid bash -c "su ${virtme_user}" 0<>"/dev/$consdev" 1>&0 2>&0
 else

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -133,8 +133,9 @@ def make_parser():
     parser.add_argument('--force-initramfs', action='store_true',
             help='Use an initramfs even if unnecessary')
 
-    parser.add_argument('--graphics', '-g', action='store_true',
-            help='Show graphical output instead of using a console')
+    parser.add_argument('--graphics', '-g', action='store',
+            nargs='?', const='', metavar="BINARY",
+            help='Show graphical output instead of using a console. An argument can be optionally specified to start a graphical application.')
 
     parser.add_argument('--quiet', '-q', action='store_true',
             help='Reduce console output verbosity.')
@@ -479,8 +480,8 @@ class KernelSource:
             self.virtme_param['force_initramfs'] = ''
 
     def _get_virtme_graphics(self, args):
-        if args.graphics:
-            self.virtme_param['graphics'] = '--graphics'
+        if args.graphics is not None:
+            self.virtme_param['graphics'] = f'--graphics "{args.graphics}"'
         else:
             self.virtme_param['graphics'] = ''
 


### PR DESCRIPTION
Allow to run individual graphical applications inside a virtme-ng session.

Change the `--graphics / -g` option to accept an optional argument. If an argument is passed, it will be interpreted as a graphical application to run inside a virtme-ng session.

virtme-ng will simply use `xinit` with a bare minimum `.xinitrc` to start the application in a minimal X graphical environment.

This is the first prototype of the functionality mentioned in issue #15.