### PR TITLE
guest: introduce virtme-ng-init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ debian/virtme-ng.debhelper.log
 debian/virtme-ng.postinst.debhelper
 debian/virtme-ng.prerm.debhelper
 debian/virtme-ng.substvars
+virtme_ng_init/target
+virtme/guest/.crate*
+virtme/guest/bin

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -5,4 +5,36 @@
 # Requirements:
 #  - apt install git-buildpackage
 
+if [ ! -d .git ]; then
+    echo "error: must be ran from a git repository"
+    exit 1
+fi
+
+# Include Rust vendor dependencies in the package (external builders usually
+# don't allow to download external packages during the build process).
+#
+# This is required to build virmte-ng-init.
+cd virtme_ng_init
+cargo vendor
+mkdir .cargo
+cat << EOF > .cargo/config.toml
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+cd -
+
+git add virtme_ng_init
+git commit -a -m "include vendor dependencies"
+
+# Create upsteam tag
+deb_tag=$(dpkg-parsechangelog -S version | cut -d- -f1)
+git tag upstream/${deb_tag}
+
 gbp buildpackage --git-ignore-branch $*
+
+# Undo packaging changes and restore original git repo
+git tag -d upstream/${deb_tag}
+git reset --hard HEAD~1

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Andrea Righi <andrea.righi@canonical.com>
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 11), dh-python, python3, python3-six, python3-setuptools, python3-argcomplete
+Build-Depends: debhelper (>= 11), dh-python, python3, python3-six, python3-setuptools, python3-argcomplete, cargo, rustc
 Homepage: https://github.com/arighi/virtme-ng
 Vcs-Git:  https://github.com/arighi/virtme-ng
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -535,9 +535,15 @@ def do_it() -> int:
     if guest_tools_path is None:
         raise ValueError("couldn't find guest tools -- virtme is installed incorrectly")
 
+    # Use the faster virtme-ng-init if we are running on a native architecture.
+    if is_native and os.path.exists(guest_tools_path + '/bin/virtme-ng-init'):
+        virtme_init_cmd = 'bin/virtme-ng-init'
+    else:
+        virtme_init_cmd = 'virtme-init'
+
     if args.root == '/':
         initcmds = [
-            f'exec {guest_tools_path}/virtme-init'
+            f'exec {guest_tools_path}/{virtme_init_cmd}'
         ]
     else:
         export_virtfs(qemu, arch, qemuargs, guest_tools_path, 'virtme.guesttools')
@@ -545,7 +551,7 @@ def do_it() -> int:
             'mkdir -p /run/virtme/guesttools',
             '/bin/mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any ' +
                     'virtme.guesttools /run/virtme/guesttools',
-            'exec /run/virtme/guesttools/virtme-init',
+            f'exec /run/virtme/guesttools/{virtme_init_cmd}',
         ]
 
     # Arrange for modules to end up in the right place

--- a/virtme_ng_init/Cargo.toml
+++ b/virtme_ng_init/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "virtme-ng-init"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nix = "0.19"

--- a/virtme_ng_init/README.md
+++ b/virtme_ng_init/README.md
@@ -1,0 +1,59 @@
+# virtme-ng-init: fast init process for virtme-ng
+
+virtme-ng-init is an extremely lightweight init process for virtme-ng [1]
+implemented in Rust.
+
+Its primary goal is to speed up the boot time of virtme-ng instances.
+
+virtme-ng-init is able to perform any necessary initialization in the
+virtualized environment, such as mounting filesystems, starting essential
+services, and configuring the system before handing over control to the main
+user-space processes (typicall a shell session).
+
+[1] https://github.com/arighi/virtme-ng
+
+# Result
+
+ - virtme-init (bash implementation):
+```
+$ time virtme-ng --exec 'uname -r'
+6.4.0-rc3-virtme
+
+real	0m1.146s
+user	0m0.829s
+sys	0m1.048s
+
+$ time virtme-ng --net user --exec 'ip addr show dev eth0'
+2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
+    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
+    inet 10.0.2.15/24 scope global eth0
+       valid_lft forever preferred_lft forever
+
+real	0m1.282s
+user	0m0.930s
+sys	0m1.219s
+```
+
+ - virtme-ng-init (Rust implementation):
+```
+$ time virtme-ng --exec 'uname -r'
+6.4.0-rc3-virtme
+
+real	0m0.906s
+user	0m0.654s
+sys	0m0.684s
+
+$ time virtme-ng --net user --exec 'ip addr show dev eth0'
+2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
+    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
+    inet 10.0.2.15/24 scope global eth0
+       valid_lft forever preferred_lft forever
+
+real	0m0.972s
+user	0m0.736s
+sys	0m0.795s
+```
+
+# Credits
+
+Author: Andrea Righi <andrea.righi@canonical.com>

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -1,0 +1,803 @@
+// SPDX-License-Identifier: GPL-3.0
+
+//! virtme-ng-init
+//!
+//! This program serves as an extremely lightweight init process for `virtme-ng` in order to speed
+//! up boot time.
+//!
+//! Its primary purpose is to perform any necessary initialization in the virtualized environment,
+//! such as mounting filesystems, starting essential services, and configuring the system before
+//! handing over control to the main user-space processes (typicall a shell session).
+//!
+//! Author: Andrea Righi <andrea.righi@canonical.com>
+
+use libc::{uname, utsname};
+use nix::fcntl::{open, OFlag};
+use nix::libc;
+use nix::sys::reboot;
+use nix::sys::stat::Mode;
+use nix::unistd::sethostname;
+use std::collections::HashMap;
+use std::env;
+use std::ffi::CStr;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::mem;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{exit, id, Command, Stdio};
+use std::thread;
+mod utils;
+
+struct MountInfo {
+    source: &'static str,
+    target: &'static str,
+    fs_type: &'static str,
+    flags: u64,
+    fsdata: &'static str,
+}
+
+const KERNEL_MOUNTS: &[MountInfo] = &[
+    MountInfo {
+        source: "sys",
+        target: "/sys",
+        fs_type: "sysfs",
+        flags: libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "proc",
+        target: "/proc",
+        fs_type: "proc",
+        flags: libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/tmp",
+        fs_type: "tmpfs",
+        flags: 0,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "devtmpfs",
+        target: "/dev",
+        fs_type: "devtmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NOEXEC,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "configfs",
+        target: "/sys/kernel/config",
+        fs_type: "configfs",
+        flags: 0,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "debugfs",
+        target: "/sys/kernel/debug",
+        fs_type: "debugfs",
+        flags: 0,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tracefs",
+        target: "/sys/kernel/tracing",
+        fs_type: "tracefs",
+        flags: 0,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "cgroup2",
+        target: "/sys/fs/cgroup",
+        fs_type: "cgroup2",
+        flags: 0,
+        fsdata: "",
+    },
+];
+
+const SYSTEM_MOUNTS: &[MountInfo] = &[
+    MountInfo {
+        source: "devpts",
+        target: "/dev/pts",
+        fs_type: "devpts",
+        flags: libc::MS_NOSUID | libc::MS_NOEXEC,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/dev/shm",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/log",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/tmp",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/spool/rsyslog",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/lib/portables",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/lib/machines",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/lib/private",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/lib/apt",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/cache",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+];
+
+fn check_init_pid() {
+    if id() != 1 {
+        utils::log(&format!("must be run as PID 1"));
+        exit(1);
+    }
+}
+
+fn poweroff() {
+    unsafe {
+        libc::sync();
+    }
+    if let Err(err) = reboot::reboot(reboot::RebootMode::RB_POWER_OFF) {
+        utils::log(&format!("error powering off: {}", err));
+        exit(1);
+    }
+    exit(0);
+}
+
+fn configure_environment() {
+    env::set_var("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin");
+}
+
+fn get_kernel_version(show_machine: bool) -> String {
+    unsafe {
+        let mut utsname: utsname = mem::zeroed();
+        if uname(&mut utsname) == -1 {
+            return String::from("None");
+        }
+        let release = CStr::from_ptr(utsname.release.as_ptr())
+            .to_string_lossy()
+            .into_owned();
+        if show_machine {
+            let machine = CStr::from_ptr(utsname.machine.as_ptr())
+                .to_string_lossy()
+                .into_owned();
+            format!("{} {}", release, machine)
+        } else {
+            release
+        }
+    }
+}
+
+fn get_active_console() -> Option<String> {
+    // See Documentation/filesystems/proc.rst for /proc/consoles documentation.
+    match File::open("/proc/consoles") {
+        Ok(file) => {
+            let reader = BufReader::new(file);
+
+            for line in reader.lines() {
+                if let Ok(line) = line {
+                    if line.chars().nth(27) == Some('C') {
+                        let console = line.split(' ').next()?.to_string();
+                        return Some(format!("/dev/{}", console));
+                    }
+                }
+            }
+            None
+        }
+        Err(error) => {
+            utils::log(&format!("failed to open /proc/consoles: {}", error));
+            None
+        }
+    }
+}
+
+fn configure_hostname() {
+    if let Ok(hostname) = env::var("virtme_hostname") {
+        if let Err(err) = sethostname(hostname) {
+            utils::log(&format!("failed to change hostname: {}", err));
+        }
+    } else {
+        utils::log(&format!("virtme_hostname is not defined"));
+    }
+}
+
+fn run_systemd_tmpfiles() {
+    let args: &[&str] = &[
+        "--create",
+        "--boot",
+        "--exclude-prefix=/dev",
+        "--exclude-prefix=/root",
+    ];
+    utils::run_cmd("systemd-tmpfiles", args);
+}
+
+fn generate_fstab() -> io::Result<()> {
+    utils::create_file("/tmp/fstab", 0o0664, "").ok();
+    utils::do_mount("/tmp/fstab", "/etc/fstab", "", libc::MS_BIND, "");
+    Ok(())
+}
+
+fn generate_shadow() -> io::Result<()> {
+    utils::create_file("/tmp/shadow", 0o0644, "").ok();
+
+    let input_file = File::open("/etc/passwd")?;
+    let output_file = File::create("/tmp/shadow")?;
+
+    let reader = BufReader::new(input_file);
+    let mut writer = BufWriter::new(output_file);
+
+    for line in reader.lines() {
+        let line = line?;
+        let parts: Vec<&str> = line.split(':').collect();
+
+        if !parts.is_empty() {
+            let username = parts[0];
+            writeln!(writer, "{}:!:::::::", username)?;
+        }
+    }
+    utils::do_mount("/tmp/shadow", "/etc/shadow", "", libc::MS_BIND, "");
+
+    Ok(())
+}
+
+fn generate_sudoers() -> io::Result<()> {
+    if let Ok(user) = env::var("virtme_user") {
+        let fname = "/tmp/sudoers";
+        utils::create_file(fname, 0o0440, "").ok();
+        let mut file = File::create(fname)?;
+        let content = format!(
+            "root ALL = (ALL) NOPASSWD: ALL\n{} ALL = (ALL) NOPASSWD: ALL\n",
+            user
+        );
+        file.write_all(content.as_bytes())?;
+        utils::do_mount(fname, "/etc/sudoers", "", libc::MS_BIND, "");
+    }
+    Ok(())
+}
+
+fn override_system_files() {
+    generate_fstab().ok();
+    generate_shadow().ok();
+    generate_sudoers().ok();
+}
+
+fn set_cwd() {
+    if let Ok(dir) = env::var("virtme_chdir") {
+        if let Err(err) = env::set_current_dir(dir) {
+            utils::log(&format!("error changing directory: {}", err));
+        }
+    }
+}
+
+fn symlink_fds() {
+    let fd_links: HashMap<&str, &str> = vec![
+        ("/proc/self/fd", "/dev/fd"),
+        ("/proc/self/fd/0", "/dev/stdin"),
+        ("/proc/self/fd/1", "/dev/stdout"),
+        ("/proc/self/fd/2", "/dev/stderr"),
+    ]
+    .into_iter()
+    .collect();
+
+    // Install /proc/self/fd symlinks into /dev if not already present.
+    for (src, dst) in fd_links.iter() {
+        if !std::path::Path::new(dst).exists() {
+            utils::do_symlink(src, dst);
+        }
+    }
+}
+
+fn mount_kernel_filesystems() {
+    for mount_info in KERNEL_MOUNTS {
+        utils::do_mount(
+            mount_info.source,
+            mount_info.target,
+            mount_info.fs_type,
+            mount_info.flags,
+            mount_info.fsdata,
+        )
+    }
+}
+
+fn mount_virtme_overlays() {
+    for (key, path) in env::vars() {
+        if key.starts_with("virtme_rw_overlay") {
+            let dir = &format!("/tmp/{}", key);
+            let upperdir = &format!("{}/upper", dir);
+            let workdir = &format!("{}/work", dir);
+            let mnt_opts = &format!(
+                "xino=off,lowerdir={},upperdir={},workdir={}",
+                path, upperdir, workdir
+            );
+            utils::do_mkdir(dir);
+            utils::do_mkdir(upperdir);
+            utils::do_mkdir(workdir);
+            utils::do_mount(&key, &path, "overlay", 0, mnt_opts);
+        }
+    }
+}
+
+fn mount_virtme_initmounts() {
+    for (key, path) in env::vars() {
+        if key.starts_with("virtme_initmount") {
+            utils::do_mkdir(&path);
+            utils::do_mount(
+                &key.replace("_", "."),
+                &path,
+                "9p",
+                0,
+                "version=9p2000.L,trans=virtio,access=any",
+            );
+        }
+    }
+}
+
+fn mount_kernel_modules() {
+    let kver = get_kernel_version(false);
+    let mod_dir = format!("/lib/modules/{}", kver);
+
+    if env::var("virtme_root_mods").is_ok() {
+        // /lib/modules is already set up.
+    } else if let Ok(dir) = env::var("virtme_link_mods") {
+        utils::do_mount("none", "/lib/modules/", "tmpfs", 0, "");
+        utils::do_symlink(&dir, &mod_dir);
+    } else if Path::new(&mod_dir).exists() {
+        // We have mismatched modules. Mask them off.
+        utils::do_mount("disallow_kmod", &mod_dir, "tmpfs", 0, "ro,mode=0000");
+    }
+}
+
+fn mount_sys_filesystems() {
+    utils::do_mkdir("/dev/pts");
+    utils::do_mkdir("/dev/shm");
+    utils::do_mkdir("/run/dbus");
+
+    for mount_info in SYSTEM_MOUNTS {
+        utils::do_mount(
+            mount_info.source,
+            mount_info.target,
+            mount_info.fs_type,
+            mount_info.flags,
+            mount_info.fsdata,
+        )
+    }
+}
+
+fn fix_dpkg_locks() {
+    if !Path::new("/var/lib/dpkg").exists() {
+        return;
+    }
+    let lock_files = vec![
+        "/var/lib/dpkg/lock",
+        "/var/lib/dpkg/lock-frontend",
+        "/var/lib/dpkg/triggers/Lock",
+    ];
+    for path in &lock_files {
+        let fname = Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if fname.is_empty() {
+            continue;
+        }
+        let src_file = format!("/tmp/{}", fname);
+        utils::create_file(&src_file, 0o0640, "").ok();
+        utils::do_mount(&src_file, path, "", libc::MS_BIND, "");
+    }
+}
+
+fn fix_packaging_files() {
+    fix_dpkg_locks();
+}
+
+fn disable_uevent_helper() {
+    let uevent_helper_path = "/sys/kernel/uevent_helper";
+
+    if Path::new(uevent_helper_path).exists() {
+        // This kills boot performance.
+        utils::log("you have CONFIG_UEVENT_HELPER on, turn it off");
+        let mut file = OpenOptions::new().write(true).open(uevent_helper_path).ok();
+        match &mut file {
+            Some(file) => {
+                write!(file, "").ok();
+            }
+            None => {
+                utils::log(&format!("error opening {}", uevent_helper_path));
+            }
+        }
+    }
+}
+
+fn find_udevd() -> Option<PathBuf> {
+    let mut udevd = PathBuf::new();
+
+    if PathBuf::from("/usr/lib/systemd/systemd-udevd").exists() {
+        udevd = PathBuf::from("/usr/lib/systemd/systemd-udevd");
+    } else if PathBuf::from("/lib/systemd/systemd-udevd").exists() {
+        udevd = PathBuf::from("/lib/systemd/systemd-udevd");
+    } else if let Ok(path) = env::var("PATH") {
+        for dir in path.split(':') {
+            let udevd_path = PathBuf::from(dir).join("udevd");
+            if udevd_path.exists() {
+                udevd = udevd_path;
+                break;
+            }
+        }
+    }
+    if udevd.exists() {
+        Some(udevd)
+    } else {
+        None
+    }
+}
+
+fn run_udevd() -> Option<thread::JoinHandle<()>> {
+    if let Some(udevd_path) = find_udevd() {
+        let handle = thread::spawn(move || {
+            disable_uevent_helper();
+            let args: &[&str] = &["--daemon", "--resolve-names=never"];
+            utils::run_cmd(&udevd_path.to_string_lossy(), args);
+            utils::log("triggering udev coldplug");
+            utils::run_cmd("udevadm", &["trigger", "--type=subsystems", "--action=add"]);
+            utils::run_cmd("udevadm", &["trigger", "--type=devices", "--action=add"]);
+            utils::log("waiting for udev to settle");
+            utils::run_cmd("udevadm", &["settle"]);
+            utils::log("udev is done");
+        });
+        Some(handle)
+    } else {
+        utils::log("unable to find udevd, skip udev.");
+        None
+    }
+}
+
+fn get_guest_tools_dir() -> Option<String> {
+    if let Ok(current_exe) = env::current_exe() {
+        if let Some(parent_dir) = current_exe.parent() {
+            if let Some(dir) = parent_dir.to_str() {
+                return Some(dir.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn get_network_device() -> Option<String> {
+    let virtio_net_dir = "/sys/bus/virtio/drivers/virtio_net";
+    if let Ok(entries) = std::fs::read_dir(virtio_net_dir) {
+        // Sort and get the first entry in this directory
+        let mut sorted_entries: Vec<_> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect();
+        sorted_entries.sort();
+
+        if let Some(first_entry) = sorted_entries.first() {
+            let net_dir = first_entry.join("net");
+            if let Ok(net_entries) = std::fs::read_dir(net_dir) {
+                if let Some(first_net_entry) = net_entries
+                    .filter_map(|entry| entry.ok())
+                    .map(|entry| entry.file_name())
+                    .filter_map(|name| name.to_str().map(|s| s.to_owned()))
+                    .next()
+                {
+                    return Some(first_net_entry);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn setup_network() -> Option<thread::JoinHandle<()>> {
+    utils::run_cmd("ip", &["link", "set", "dev", "lo", "up"]);
+    if let Ok(cmdline) = std::fs::read_to_string("/proc/cmdline") {
+        if cmdline.contains("virtme.dhcp") {
+            if let Some(guest_tools_dir) = get_guest_tools_dir() {
+                if let Some(network_device) = get_network_device() {
+                    let handle = thread::spawn(move || {
+                        let args = [
+                            "udhcpc",
+                            "-i",
+                            &network_device,
+                            "-n",
+                            "-q",
+                            "-f",
+                            "-s",
+                            &format!("{}/virtme-udhcpc-script", guest_tools_dir),
+                        ];
+                        utils::run_cmd("busybox", &args);
+                    });
+                    return Some(handle);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn run_user_script() {
+    if !std::path::Path::new("/dev/virtio-ports/virtme.stdin").exists()
+        || !std::path::Path::new("/dev/virtio-ports/virtme.stdout").exists()
+        || !std::path::Path::new("/dev/virtio-ports/virtme.stderr").exists()
+        || !std::path::Path::new("/dev/virtio-ports/virtme.dev_stdout").exists()
+        || !std::path::Path::new("/dev/virtio-ports/virtme.dev_stderr").exists()
+    {
+        utils::log(
+            "virtme-init: cannot find script I/O ports; make sure virtio-serial is available",
+        );
+    } else {
+        // Re-create stdout/stderr to connect to the virtio-serial ports.
+        let io_files: HashMap<&str, &str> = vec![
+            ("/dev/virtio-ports/virtme.dev_stdin", "/dev/stdin"),
+            ("/dev/virtio-ports/virtme.dev_stdout", "/dev/stdout"),
+            ("/dev/virtio-ports/virtme.dev_stderr", "/dev/stderr"),
+        ]
+        .into_iter()
+        .collect();
+        for (src, dst) in io_files.iter() {
+            if std::path::Path::new(dst).exists() {
+                utils::do_unlink(dst);
+            }
+            utils::do_symlink(src, dst);
+        }
+
+        // Detach the process from the controlling terminal
+        let flags = libc::O_RDWR;
+        let mode = Mode::empty();
+        let tty_in = open(
+            "/dev/virtio-ports/virtme.stdin",
+            OFlag::from_bits_truncate(flags),
+            mode,
+        )
+        .expect("failed to open console.");
+        let tty_out = open(
+            "/dev/virtio-ports/virtme.stdout",
+            OFlag::from_bits_truncate(flags),
+            mode,
+        )
+        .expect("failed to open console.");
+        let tty_err = open(
+            "/dev/virtio-ports/virtme.stderr",
+            OFlag::from_bits_truncate(flags),
+            mode,
+        )
+        .expect("failed to open console.");
+
+        clear_virtme_envs();
+        unsafe {
+            Command::new("/run/virtme/data/script")
+                .pre_exec(move || {
+                    nix::libc::setsid();
+                    libc::close(libc::STDIN_FILENO);
+                    libc::close(libc::STDOUT_FILENO);
+                    libc::close(libc::STDERR_FILENO);
+                    // Make stdin a controlling tty.
+                    let stdin_fd = libc::dup2(tty_in, libc::STDIN_FILENO);
+                    nix::libc::ioctl(stdin_fd, libc::TIOCSCTTY, 1);
+                    libc::dup2(tty_out, libc::STDOUT_FILENO);
+                    libc::dup2(tty_err, libc::STDERR_FILENO);
+                    Ok(())
+                })
+                .output()
+                .expect("Failed to execute script");
+        }
+    }
+}
+
+fn setup_root_home() {
+    utils::do_mkdir("/tmp/roothome");
+    utils::do_mount("/tmp/roothome", "/root", "", libc::MS_BIND, "");
+    env::set_var("HOME", "/tmp/roothome");
+}
+
+fn clear_virtme_envs() {
+    // Parameters that start with virtme_* shouldn't pollute the environment.
+    for (key, _) in env::vars() {
+        if key.starts_with("virtme_") {
+            env::remove_var(key);
+        }
+    }
+}
+
+fn configure_terminal(consdev: &str) {
+    if let Ok(params) = env::var("virtme_stty_con") {
+        let output = Command::new("stty")
+            .args(params.split_whitespace())
+            .stdin(std::fs::File::open(consdev).unwrap())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            // Replace the current init process with a shell session.
+            .output();
+        utils::log(String::from_utf8_lossy(&output.unwrap().stderr).trim_end_matches('\n'));
+    }
+}
+
+fn detach_from_terminal(tty_fd: libc::c_int) {
+    // Detach the process from the controlling terminal
+    unsafe {
+        nix::libc::setsid();
+        libc::close(libc::STDIN_FILENO);
+        libc::close(libc::STDOUT_FILENO);
+        libc::close(libc::STDERR_FILENO);
+        let stdin_fd = libc::dup2(tty_fd, libc::STDIN_FILENO);
+        nix::libc::ioctl(stdin_fd, libc::TIOCSCTTY, 1);
+        libc::dup2(tty_fd, libc::STDOUT_FILENO);
+        libc::dup2(tty_fd, libc::STDERR_FILENO);
+    }
+}
+
+fn run_shell(tty_fd: libc::c_int, args: Vec<String>) {
+    unsafe {
+        Command::new("bash")
+            .args(args.into_iter())
+            .pre_exec(move || {
+                detach_from_terminal(tty_fd);
+                Ok(())
+            })
+            .output()
+            .expect("Failed to start shell session");
+    }
+}
+
+fn run_user_gui(tty_fd: libc::c_int, app: &str) {
+    // Generate a bare minimum xinitrc
+    let xinitrc = "/tmp/.xinitrc";
+    if let Err(err) = utils::create_file(xinitrc, 0o0644, &format!("exec {}", app)) {
+        utils::log(&format!("failed to generate {}: {}", xinitrc, err));
+        return;
+    }
+    // Run graphical app using xinit directly
+    let mut args: Vec<String> = vec!["-l".to_owned(), "-c".to_owned()];
+    if let Ok(user) = env::var("virtme_user") {
+        // Try to fix permissions on the virtual consoles, we are starting X
+        // directly here so we may need extra permissions on the tty devices.
+        utils::run_cmd("bash", &["-c", &format!("chown {} /dev/char/*", user)]);
+
+        // Start xinit directly.
+        args.push(format!("su - {} -c 'xinit /tmp/.xinitrc'", user));
+    } else {
+        args.push("xinit /tmp/.xinitrc".to_owned());
+    }
+    run_shell(tty_fd, args);
+}
+
+fn run_user_shell(tty_fd: libc::c_int) {
+    let mut args: Vec<String> = vec!["-l".to_owned()];
+    if let Ok(user) = env::var("virtme_user") {
+        args.push("-c".to_owned());
+        args.push(format!("su - {}", user));
+    }
+    run_shell(tty_fd, args);
+}
+
+fn run_user_session() {
+    let consdev = match get_active_console() {
+        Some(console) => console,
+        None => {
+            utils::log("failed to determine console");
+            Command::new("bash").arg("-l").exec();
+            return;
+        }
+    };
+    configure_terminal(consdev.as_str());
+
+    let flags = libc::O_RDWR | libc::O_NONBLOCK;
+    let mode = Mode::empty();
+    let tty_fd = open(consdev.as_str(), OFlag::from_bits_truncate(flags), mode)
+        .expect("failed to open console");
+
+    if let Ok(app) = env::var("virtme_graphics") {
+        run_user_gui(tty_fd, &app);
+    }
+    run_user_shell(tty_fd);
+}
+
+fn setup_user_session() {
+    utils::log("initialization done");
+    print_logo();
+    setup_root_home();
+}
+
+fn run_misc_services() -> Option<thread::JoinHandle<()>> {
+    let handle = thread::spawn(move || {
+        symlink_fds();
+        mount_virtme_initmounts();
+        fix_packaging_files();
+        override_system_files();
+    });
+    Some(handle)
+}
+
+fn print_logo() {
+    let logo = r#"
+          _      _
+   __   _(_)_ __| |_ _ __ ___   ___       _ __   __ _
+   \ \ / / |  __| __|  _   _ \ / _ \_____|  _ \ / _  |
+    \ V /| | |  | |_| | | | | |  __/_____| | | | (_| |
+     \_/ |_|_|   \__|_| |_| |_|\___|     |_| |_|\__  |
+                                                |___/"#;
+    println!("{}", logo.trim_start_matches("\n"));
+    println!("   kernel version: {}\n", get_kernel_version(true));
+}
+
+fn main() {
+    // Make sure to always run as PID 1.
+    check_init_pid();
+
+    // Basic system initialization (order is important here).
+    configure_environment();
+    configure_hostname();
+    mount_kernel_filesystems();
+    mount_virtme_overlays();
+    mount_sys_filesystems();
+    mount_kernel_modules();
+    run_systemd_tmpfiles();
+
+    // Service initialization (some services can be parallelized here).
+    let mut handles: Vec<Option<thread::JoinHandle<()>>> = Vec::new();
+    handles.push(run_udevd());
+    handles.push(setup_network());
+    handles.push(run_misc_services());
+
+    // Wait for the completion of the detached services.
+    for handle in handles.into_iter().flatten() {
+        handle.join().unwrap();
+    }
+
+    // Start user session (batch or interactive).
+    set_cwd();
+    if utils::is_file_executable("/run/virtme/data/script") {
+        run_user_script();
+    } else {
+        setup_user_session();
+        run_user_session();
+    }
+
+    // Shutdown the system.
+    poweroff();
+}

--- a/virtme_ng_init/src/utils.rs
+++ b/virtme_ng_init/src/utils.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0
+
+//! virtme-ng-init: generic helper functions
+//!
+//! Author: Andrea Righi <andrea.righi@canonical.com>
+
+use nix::libc;
+use nix::mount::{mount, MsFlags};
+use nix::sys::stat::Mode;
+use std::ffi::CString;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::os::unix::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+
+static PROG_NAME: &'static str = "virtme-ng-init";
+
+pub fn log(msg: &str) {
+    if msg.is_empty() {
+        return;
+    }
+    let msg = format!("{}: {}", PROG_NAME, msg.trim_end_matches('\n'));
+    let mut file = OpenOptions::new().write(true).open("/dev/kmsg").ok();
+    match &mut file {
+        Some(file) => {
+            let msg = format!("<6>{}\n", msg);
+            file.write(msg.as_bytes()).ok();
+        }
+        None => {
+            println!("{}", msg);
+        }
+    }
+}
+
+pub fn do_mkdir(path: &str) {
+    let dmask = libc::S_IRWXU | libc::S_IRGRP | libc::S_IXGRP | libc::S_IROTH | libc::S_IXOTH;
+    nix::unistd::mkdir(path, Mode::from_bits_truncate(dmask as u32)).ok();
+}
+
+pub fn do_unlink(path: &str) {
+    match std::fs::remove_file(path) {
+        Ok(_) => (),
+        Err(err) => {
+            log(&format!("failed to unlink file {}: {}", path, err));
+        }
+    }
+}
+
+fn do_touch(path: &str, mode: u32) {
+    fn _do_touch(path: &str, mode: u32) -> std::io::Result<()> {
+        let file = File::create(path)?;
+        let permissions = std::fs::Permissions::from_mode(mode);
+        file.set_permissions(permissions)?;
+
+        Ok(())
+    }
+    if let Err(err) = _do_touch(path, mode) {
+        log(&format!("error creating file: {}", err));
+    }
+}
+
+pub fn create_file(fname: &str, mode: u32, content: &str) -> io::Result<()> {
+    do_touch(fname, mode);
+    if !content.is_empty() {
+        let mut file = File::create(fname)?;
+        file.write_all(content.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+pub fn do_symlink(src: &str, dst: &str) {
+    match fs::symlink(src, dst) {
+        Ok(_) => (),
+        Err(err) => {
+            log(&format!(
+                "failed to create symlink {} -> {}: {}",
+                src, dst, err
+            ));
+        }
+    }
+}
+
+pub fn is_file_executable(file_path: &str) -> bool {
+    if let Ok(metadata) = std::fs::metadata(file_path) {
+        let permissions = metadata.permissions();
+        permissions.mode() & 0o111 != 0
+    } else {
+        false
+    }
+}
+
+pub fn do_mount(source: &str, target: &str, fstype: &str, flags: u64, fsdata: &str) {
+    let source_cstr = CString::new(source).expect("CString::new failed");
+    let fstype_cstr = CString::new(fstype).expect("CString::new failed");
+    let fsdata_cstr = CString::new(fsdata).expect("CString::new failed");
+
+    let result = mount(
+        Some(source_cstr.as_ref()),
+        target,
+        Some(fstype_cstr.as_ref()),
+        MsFlags::from_bits_truncate(flags),
+        Some(fsdata_cstr.as_ref()),
+    );
+    if let Err(err) = result {
+        log(&format!(
+            "mount {} -> {}: {}",
+            source,
+            target,
+            err.to_string()
+        ));
+    }
+}
+
+pub fn run_cmd(cmd: &str, args: &[&str]) {
+    let output = Command::new(cmd)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok();
+    log(String::from_utf8_lossy(&output.unwrap().stderr).trim_end_matches('\n'));
+}


### PR DESCRIPTION
Overview
=======

virtme-ng-init is an extremely lightweight init process for virtme-ng implemented in Rust, as a replacement of the Bash virtme-init implementation.

Its primary goal is to speed up the boot time of virtme-ng instances.

virtme-ng-init is able to perform any necessary initialization in the virtualized environment required by virtme-ng, such as mounting filesystems, starting essential services, and configuring the system before handing over control to the main user-space processes.

NOTE: at the moment virtme-ng-init is only used when running native architecture instances.

Result
======

 - virtme-init (Bash implementation):
```
$ time virtme-ng --exec 'uname -r'
6.4.0-rc3-virtme

real	0m1.146s
user	0m0.829s
sys	0m1.048s

$ time virtme-ng --net user --exec 'ip addr show dev eth0' 2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 scope global eth0
       valid_lft forever preferred_lft forever

real	0m1.282s
user	0m0.930s
sys	0m1.219s
```

 - virtme-ng-init (Rust implementation):
```
$ time virtme-ng --exec 'uname -r'
6.4.0-rc3-virtme

real	0m0.906s
user	0m0.654s
sys	0m0.684s

$ time virtme-ng --net user --exec 'ip addr show dev eth0' 2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 scope global eth0
       valid_lft forever preferred_lft forever

real	0m0.972s
user	0m0.736s
sys	0m0.795s
```

In conclusion with virtme-ng-init in this particular environment (AMD Ryzen 7 5800X) we can start fully functional VMs with networking up in less than 1 sec.

This addresses issue #13.

Link: https://github.com/arighi/virtme-ng-init