### PR TITLE
virtme-ng: allow to run snaps inside virtme-ng instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ Examples
    (virtme-ng is started in graphical mode)
 ```
 
+ - Run the `steam` snap inside a virtme-ng instance using the
+   6.2.0-1003-lowlatency kernel:
+```
+   $ vng -r 6.2.0-1003-lowlatency --enable-snaps --net user -g /snap/bin/steam
+
+   (virtme-ng is started in graphical mode)
+```
+
 Implementation details
 ======================
 
@@ -316,6 +324,11 @@ Troubleshooting
 ```
   $ vng --clean --build-host HOSTNAME
 ```
+
+ - Snap support is still experimental and something may not work as expected
+   (keep in mind that virtme-ng will try to run snapd in a bare minimum system
+   environment without systemd), if some snaps are not running try to disable
+   apparmor, adding `--append="apparmor=0"` to the virtme-ng command line.
 
 Contributing
 ============

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
             'bin/virtme-ng-init',
             'virtme-init',
             'virtme-udhcpc-script',
+            'virtme-snapd-script',
         ],
     },
     include_package_data=True,

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -142,6 +142,14 @@ _GENERIC_CONFIG_OPTIONAL = [
     'CONFIG_DRM_BOCHS=y',
     'CONFIG_VIRTIO_IOMMU=y',
 
+    '# Required to run snaps',
+    'CONFIG_SECURITYFS=y',
+    'CONFIG_CGROUP_BPF=y',
+    'CONFIG_SQUASHFS=y',
+    'CONFIG_SQUASHFS_XZ=y',
+    'CONFIG_SQUASHFS_ZSTD=y',
+    'CONFIG_FUSE_FS=y',
+
     '# Unnecessary configs',
     '# CONFIG_LOCALVERSION_AUTO is not set',
     '# CONFIG_TEST_KMOD is not set',

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -496,6 +496,16 @@ def do_it() -> int:
     # Check if we need to run in quiet or verbose mode.
     verbose = not (args.quiet or args.script_sh or args.script_exec)
 
+    # In verbose mode, check and warn if snapd requires permission adjustments.
+    if verbose:
+        snapd_state = '/var/lib/snapd/state.json'
+        if os.path.exists(snapd_state):
+            file_status = os.stat(snapd_state)
+            if file_status.st_mode & 0o004 == 0:
+                sys.stderr.write(f"\nWARNING: {snapd_state} is not readable, snap support is disabled.\n")
+                sys.stderr.write(f"Run `sudo chmod +r {snapd_state}` on the **host** to enable snaps.\n")
+                sys.stderr.write(f"This may have security implications on the host!\n\n")
+
     need_initramfs = args.force_initramfs or qemu.cannot_overmount_virtfs
 
     config = mkinitramfs.Config()

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -206,18 +206,20 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
     busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
 fi
 
-# If snapd is present in the system try to start it, to properly support snaps.
-snapd_bin="/usr/lib/snapd/snapd";
-if [ -e "$snapd_bin" ]; then
-    snapd_state="/var/lib/snapd/state.json"
-    if [ -e "$snapd_state" ]; then
-	permissions=$((0$(stat -c "%a" "$snapd_state") & 0x4))
-        if [ $permissions -ne 0 ]; then
-            $(dirname $0)/virtme-snapd-script
-            $snapd_bin >/dev/null 2>&1 </dev/null &
-            snapd_apparmor_bin=/usr/lib/snapd/snapd-apparmor
-            if [ -e $snapd_apparmor_bin ]; then
-                $snapd_apparmor_bin start
+if cat /proc/cmdline |grep -q -E '(^| )virtme.snapd($| )'; then
+    # If snapd is present in the system try to start it, to properly support snaps.
+    snapd_bin="/usr/lib/snapd/snapd";
+    if [ -e "$snapd_bin" ]; then
+        snapd_state="/var/lib/snapd/state.json"
+        if [ -e "$snapd_state" ]; then
+            permissions=$((0$(stat -c "%a" "$snapd_state") & 0x4))
+            if [ $permissions -ne 0 ]; then
+                $(dirname $0)/virtme-snapd-script
+                $snapd_bin >/dev/null 2>&1 </dev/null &
+                snapd_apparmor_bin=/usr/lib/snapd/snapd-apparmor
+                if [ -e $snapd_apparmor_bin ]; then
+                    $snapd_apparmor_bin start >/dev/null 2>&1 </dev/null
+                fi
             fi
         fi
     fi

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -54,8 +54,11 @@ fi
 [ -e /var/lib/private ] && mount -t tmpfs tmpfs /var/lib/private &
 [ -e /var/cache ] && mount -t tmpfs tmpfs /var/cache &
 
-# Additional rw dirs required by apt
+# Additional rw dirs required by apt (if present)
 [ -e /var/lib/apt ] && mount -t tmpfs tmpfs /var/lib/apt &
+
+# Additional rw dirs required by snapd (if present)
+[ -e /var/lib/snapd/cookie ] && mount -t tmpfs tmpfs /var/lib/snapd/cookie &
 
 # Fix up /etc a little bit
 touch /tmp/fstab
@@ -160,6 +163,7 @@ fi
 mount -t configfs configfs /sys/kernel/config &>/dev/null
 mount -t debugfs debugfs /sys/kernel/debug &>/dev/null
 mount -t tracefs tracefs /sys/kernel/tracing &>/dev/null
+mount -t securityfs securityfs /sys/kernel/security &>/dev/null
 
 # Set up cgroup mount points (mount cgroupv2 hierarchy by default)
 mount -t cgroup2 cgroup2 /sys/fs/cgroup
@@ -200,6 +204,23 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
     # udev is liable to rename the interface out from under us.
     virtme_net=`ls "$(ls -d /sys/bus/virtio/drivers/virtio_net/virtio* |sort -g |head -n1)"/net`
     busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
+fi
+
+# If snapd is present in the system try to start it, to properly support snaps.
+snapd_bin="/usr/lib/snapd/snapd";
+if [ -e "$snapd_bin" ]; then
+    snapd_state="/var/lib/snapd/state.json"
+    if [ -e "$snapd_state" ]; then
+	permissions=$((0$(stat -c "%a" "$snapd_state") & 0x4))
+        if [ $permissions -ne 0 ]; then
+            $(dirname $0)/virtme-snapd-script
+            $snapd_bin >/dev/null 2>&1 </dev/null &
+            snapd_apparmor_bin=/usr/lib/snapd/snapd-apparmor
+            if [ -e $snapd_apparmor_bin ]; then
+                $snapd_apparmor_bin start
+            fi
+        fi
+    fi
 fi
 
 if [[ -x /run/virtme/data/script ]]; then

--- a/virtme/guest/virtme-snapd-script
+++ b/virtme/guest/virtme-snapd-script
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Initialize a snap cgroup to emulate a systemd environment, tricking snapd
+# into recognizing our system as a valid one.
+
+mkdir /sys/fs/cgroup/snap.virtme.service
+echo 1 > /sys/fs/cgroup/snap.virtme.service/cgroup.procs

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -101,6 +101,9 @@ def make_parser():
     parser.add_argument('--no-virtme-ng-init', action='store_true',
             help='Fallback to the bash virtme-init (useful for debugging/development)')
 
+    parser.add_argument('--enable-snaps', action='store_true',
+            help='Allow to execute snaps inside virtme-ng')
+
     parser.add_argument('--debug', action='store_true',
             help='Start the instance with debugging enabled (allow to generate crash dumps)')
 
@@ -633,6 +636,12 @@ class KernelSource:
         else:
             self.virtme_param['balloon'] = ''
 
+    def _get_virtme_enable_snaps(self, args):
+        if args.enable_snaps:
+            self.virtme_param['enable_snaps'] = '--enable-snaps'
+        else:
+            self.virtme_param['enable_snaps'] = ''
+
     def _get_virtme_busybox(self, args):
         if args.busybox is not None:
             self.virtme_param['busybox'] = '--busybox ' + args.busybox
@@ -691,6 +700,7 @@ class KernelSource:
         self._get_virtme_cpus(args)
         self._get_virtme_memory(args)
         self._get_virtme_balloon(args)
+        self._get_virtme_enable_snaps(args)
         self._get_virtme_busybox(args)
         self._get_virtme_qemu(args)
         self._get_virtme_qemu_opts(args)
@@ -723,6 +733,7 @@ class KernelSource:
             f'{self.virtme_param["cpus"]} ' +
             f'{self.virtme_param["memory"]} ' +
             f'{self.virtme_param["balloon"]} ' +
+            f'{self.virtme_param["enable_snaps"]} ' +
             f'{self.virtme_param["busybox"]} ' +
             f'{self.virtme_param["qemu"]} ' +
             f'{self.virtme_param["qemu_opts"]} '

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -767,37 +767,40 @@ fn setup_user_session() {
 }
 
 fn run_snapd() {
-    // If snapd is present in the system try to start it, to properly support snaps.
-    let snapd_bin = "/usr/lib/snapd/snapd";
-    if !Path::new(snapd_bin).exists() {
-        return;
-    }
-    let snapd_state = "/var/lib/snapd/state.json";
-    if !Path::new(snapd_state).exists() {
-        return;
-    }
-    if !utils::check_file_permissions(snapd_state, 0o004) {
-        return;
-    }
-    if let Some(guest_tools_dir) = get_guest_tools_dir() {
-        utils::run_cmd(&format!("{}/virtme-snapd-script", guest_tools_dir), &[]);
-    }
-    Command::new(snapd_bin)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok();
-    let snapd_apparmor_bin = "/usr/lib/snapd/snapd-apparmor";
-    if Path::new(snapd_apparmor_bin).exists() {
-        Command::new(snapd_apparmor_bin)
-            .arg("start")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .output()
-            .ok();
-
+    if let Ok(cmdline) = std::fs::read_to_string("/proc/cmdline") {
+        if cmdline.contains("virtme.snapd") {
+            // If snapd is present in the system try to start it, to properly support snaps.
+            let snapd_bin = "/usr/lib/snapd/snapd";
+            if !Path::new(snapd_bin).exists() {
+                return;
+            }
+            let snapd_state = "/var/lib/snapd/state.json";
+            if !Path::new(snapd_state).exists() {
+                return;
+            }
+            if !utils::check_file_permissions(snapd_state, 0o004) {
+                return;
+            }
+            if let Some(guest_tools_dir) = get_guest_tools_dir() {
+                utils::run_cmd(&format!("{}/virtme-snapd-script", guest_tools_dir), &[]);
+            }
+            Command::new(snapd_bin)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .ok();
+            let snapd_apparmor_bin = "/usr/lib/snapd/snapd-apparmor";
+            if Path::new(snapd_apparmor_bin).exists() {
+                Command::new(snapd_apparmor_bin)
+                    .arg("start")
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .output()
+                    .ok();
+            }
+        }
     }
 }
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -89,6 +89,13 @@ const KERNEL_MOUNTS: &[MountInfo] = &[
         fsdata: "",
     },
     MountInfo {
+        source: "securityfs",
+        target: "/sys/kernel/security",
+        fs_type: "securityfs",
+        flags: 0,
+        fsdata: "",
+    },
+    MountInfo {
         source: "cgroup2",
         target: "/sys/fs/cgroup",
         fs_type: "cgroup2",
@@ -164,6 +171,13 @@ const SYSTEM_MOUNTS: &[MountInfo] = &[
     MountInfo {
         source: "tmpfs",
         target: "/var/cache",
+        fs_type: "tmpfs",
+        flags: libc::MS_NOSUID | libc::MS_NODEV,
+        fsdata: "",
+    },
+    MountInfo {
+        source: "tmpfs",
+        target: "/var/lib/snapd/cookie",
         fs_type: "tmpfs",
         flags: libc::MS_NOSUID | libc::MS_NODEV,
         fsdata: "",
@@ -752,12 +766,48 @@ fn setup_user_session() {
     setup_root_home();
 }
 
+fn run_snapd() {
+    // If snapd is present in the system try to start it, to properly support snaps.
+    let snapd_bin = "/usr/lib/snapd/snapd";
+    if !Path::new(snapd_bin).exists() {
+        return;
+    }
+    let snapd_state = "/var/lib/snapd/state.json";
+    if !Path::new(snapd_state).exists() {
+        return;
+    }
+    if !utils::check_file_permissions(snapd_state, 0o004) {
+        return;
+    }
+    if let Some(guest_tools_dir) = get_guest_tools_dir() {
+        utils::run_cmd(&format!("{}/virtme-snapd-script", guest_tools_dir), &[]);
+    }
+    Command::new(snapd_bin)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok();
+    let snapd_apparmor_bin = "/usr/lib/snapd/snapd-apparmor";
+    if Path::new(snapd_apparmor_bin).exists() {
+        Command::new(snapd_apparmor_bin)
+            .arg("start")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok();
+
+    }
+}
+
 fn run_misc_services() -> Option<thread::JoinHandle<()>> {
     let handle = thread::spawn(move || {
         symlink_fds();
         mount_virtme_initmounts();
         fix_packaging_files();
         override_system_files();
+        run_snapd();
     });
     Some(handle)
 }

--- a/virtme_ng_init/src/utils.rs
+++ b/virtme_ng_init/src/utils.rs
@@ -82,13 +82,17 @@ pub fn do_symlink(src: &str, dst: &str) {
     }
 }
 
-pub fn is_file_executable(file_path: &str) -> bool {
+pub fn check_file_permissions(file_path: &str, mask: u32) -> bool {
     if let Ok(metadata) = std::fs::metadata(file_path) {
         let permissions = metadata.permissions();
-        permissions.mode() & 0o111 != 0
+        permissions.mode() & mask != 0
     } else {
         false
     }
+}
+
+pub fn is_file_executable(file_path: &str) -> bool {
+    check_file_permissions(file_path, 0o111)
 }
 
 pub fn do_mount(source: &str, target: &str, fstype: &str, flags: u64, fsdata: &str) {


### PR DESCRIPTION
Enable all the required (kernel and user-space) features to start snapd and execute snaps directly inside a virtme-ng instance.

The snap support is activated only if snapd is installed in the host system. This won't introduce any additional overhead in systems that don't have snap available.

In systems that have snapd available, virmte-ng will automatically start it at boot (tricking it a bit into believing that it's running in a standard systemd-enabled environment) and at this point we can start any snap as regular system binaries inside virtme-ng.

This fixes issue #21.

Open issues
===========

The main issue at the moment is that the guest requires read access to `/var/lib/snapd/state.json` that has `0600` permissions by default. Since we are running the guest as unprivileged user, by default it won't have access to the snapd state, therefore snapd cannot be started in the guest.

For this reason in order to properly support snapd inside virtme-ng we need to change the permissions mask of this file and make it readable by everyone (unless we figure out a better solution to this).

virtme-ng will print a warning in this case, to inform the user to run chmod manually (sad...) to change the permission of state.json.

However, with this change applied we can run any kind of snap inside virtme-ng, even graphic applications (using `--graphics`), such as videogames, web browsers, etc.