### PR TITLE
Use getpass.getuser() instead of os.getlogin()

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -10,6 +10,7 @@ import socket
 import shutil
 import json
 import tempfile
+import getpass
 from subprocess import check_call, check_output, Popen, DEVNULL, PIPE, CalledProcessError
 from select import select
 from pathlib import Path
@@ -304,8 +305,8 @@ def get_username():
     try:
         username = os.getlogin()
     except OSError:
-        # If os.getlogin() fails, try alternative methods
-        username = os.getenv('USER') or os.getenv('LOGNAME')
+        # If os.getlogin() fails, try alternative method
+        username = getpass.getuser()
     return username
 
 class KernelSource:

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -303,10 +303,10 @@ def create_root(destdir, arch):
 def get_username():
     """Reliably get current username."""
     try:
-        username = os.getlogin()
-    except OSError:
-        # If os.getlogin() fails, try alternative method
         username = getpass.getuser()
+    except OSError:
+        # If getpass.getuser() fails, try alternative methods
+        username = os.getenv('USER') or os.getenv('LOGNAME')
     return username
 
 class KernelSource:


### PR DESCRIPTION
Python documentation recommends the `getpass.getuser()` as a more portable and reliable alternative (at least inside Python, since thats not POSIX) of `os.getlogin()`.