### PR TITLE
virtme-ng: Don't fail on missing argcomplete

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -20,7 +20,12 @@ from subprocess import (
 )
 from select import select
 from pathlib import Path
-from argcomplete import autocomplete
+try:
+    from argcomplete import autocomplete
+except ModuleNotFoundError:
+    def autocomplete(*args, **kwargs):
+        # pylint: disable=unused-argument
+        pass
 
 from virtme.util import SilentError, get_username
 from virtme_ng.utils import CONF_FILE


### PR DESCRIPTION
The argcomplete dependency isn't critical, so let's continue on in its absence instead of blowing up (convenient for running the 'vng' command directly from the source tree without having to install any python module dependencies).