### PR TITLE
virtme-ng: Set a default for --name

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -68,6 +68,12 @@ fi
 touch /tmp/fstab
 mount --bind /tmp/fstab /etc/fstab
 
+if [[ -n "$virtme_hostname" ]]; then
+    cp /etc/hosts /tmp/hosts
+    printf '\n127.0.0.1 %s\n::1 %s\n' "$virtme_hostname" "$virtme_hostname" >> /tmp/hosts
+    mount --bind /tmp/hosts /etc/hosts
+fi
+
 # Fix dpkg if we are on a Debian-based distro
 if [ -d /var/lib/dpkg ]; then
     lock_files=(/var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/lib/dpkg/triggers/Lock)

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -205,7 +205,10 @@ def make_parser():
     parser.add_argument("--qemu", action="store", help="Use the specified QEMU binary")
 
     parser.add_argument(
-        "--name", action="store", help="Set guest hostname and qemu -name flag"
+        "--name",
+        action="store",
+        default="virtme-ng",
+        help="Set guest hostname and qemu -name flag"
     )
 
     parser.add_argument(


### PR DESCRIPTION
With virtme-ng defaulting to running as the current user instead of root, I've been finding it easy to get confused about whether my shell prompt (which includes the hostname) is from the host or the guest (since they end up identical).  Providing a recognizable default for the `--name` flag makes it easier to tell them apart.