### PR TITLE
Add tiny Makefile for building virtme-ng-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: init
+init:
+	cd virtme_ng_init && cargo install --path . --root ../virtme/guest

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,7 @@ class BuildPy(build_py):
         print(f"BUILD_VIRTME_NG_INIT: {build_virtme_ng_init}")
         # Build virtme-ng-init
         if build_virtme_ng_init:
-            check_call(
-                ["cargo", "install", "--path", ".", "--root", "../virtme/guest"],
-                cwd="virtme_ng_init",
-            )
+            check_call(["make", "init"])
             check_call(
                 ["strip", "-s", "../virtme/guest/bin/virtme-ng-init"],
                 cwd="virtme_ng_init",


### PR DESCRIPTION
This is primarily just a small convenience for building an updated virtme-ng-init when running vng from the source directory.  In order to keep the definition of "how to build init" in one place, also update setup.py to run 'make' instead of directly invoking 'cargo'.