### PR TITLE
setup.py: Add requests to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         os.path.join(os.path.dirname(__file__), "README.md"), "r", encoding="utf-8"
     ).read(),
     long_description_content_type="text/markdown",
-    install_requires=["argcomplete"],
+    install_requires=["argcomplete", "requests"],
     entry_points={
         "console_scripts": [
             "vng = virtme_ng.run:main",


### PR DESCRIPTION
If vng is installed using pipx, which starts a venv by default for the installed package, fails to find requests library. Add requests as a requirements of vng so it can be found correctly by pipx.