### PR TITLE
virtme-init: Add default secure_path

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -201,7 +201,8 @@ ip link set dev lo up
 if [[ -n "virtme_user" ]]; then
     real_sudoers=/etc/sudoers
     tmpfile="`mktemp --tmpdir=/tmp`"
-    echo "root ALL = (ALL) NOPASSWD: ALL" > $tmpfile
+    echo "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"" > $tmpfile
+    echo "root ALL = (ALL) NOPASSWD: ALL" >> $tmpfile
     echo "${virtme_user} ALL = (ALL) NOPASSWD: ALL" >> $tmpfile
     chmod 440 "$tmpfile"
     if [ ! -f "$real_sudoers" ]; then


### PR DESCRIPTION
When using vng without the --no-virtme-ng-init, running a command that resides on /sbin with sudo doesn't work:

$ vng --no-virtme-me-init
$ mpdesouza@virtme-ng:~/git/linux> modprobe
Absolute path to 'modprobe' is '/usr/sbin/modprobe', so running it may require superuser privileges (eg. root). $ mpdesouza@virtme-ng:~/git/linux> sudo modprobe
sudo: modprobe: command not found

In essence, the path when running sudo is the same of the normal user. Fix this problem by creating a secure_path when running with sudo, which includes /sbin  and usr/sbin along with the common binary paths. With the fix applied, modprobe is found as expected:

$ vng --no-virtme-me-init
$ mpdesouza@virtme-ng:~/git/linux> modprobe
Absolute path to 'modprobe' is '/usr/sbin/modprobe', so running it may require superuser privileges (eg. root). $ mpdesouza@virtme-ng:~/git/linux> sudo modprobe
modprobe: ERROR: missing parameters. See -h.