### PR TITLE
virtme: Fix infinite loop when finding kernel modules

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -334,7 +334,7 @@ class Kernel:
 
 
 def get_rootfs_from_kernel_path(path):
-    while path != "/" and not os.path.exists(path + "/lib/modules"):
+    while path and path != "/" and not os.path.exists(path + "/lib/modules"):
         path, _ = os.path.split(path)
     return os.path.abspath(path)
 


### PR DESCRIPTION
The get_rootfs_from_kernel_path() function finds a candidate location for kernel modules by walking directories starting from the kimg location up to the root of the file system, and checking for a lib/modules/ subdirectory in each of them. This process repeats until the file system root, "/", is reached.

If kimg is not an absolute path, the path variable in the loop will eventually become an empty string, without ever being equal to "/". The loop will then run forever. Fix it by stopping when the path is an empty string. This will return an empty string as the modules' root directory, and the caller will disable handling of modules.