### PR TITLE
docker support

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,26 @@
+name: Run
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run:
+    runs-on: ubuntu-22.04
+    steps:
+      ### DEPENDENCIES ###
+
+      # Hard turn-off interactive mode
+      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+
+      # Install dependencies
+      - run: sudo apt update
+      - run: sudo apt install --yes git qemu-kvm udev iproute2 busybox-static coreutils python3-requests libvirt-clients kbd kmod file rsync zstd udev
+
+      ### END DEPENDENCIES ###
+
+      # Checkout git repository
+      - uses: actions/checkout@v4
+
+      # Run `uname -r` using a vanilla v6.6 kernel
+      - run: ./vng -r v6.6 -- uname -r

--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ Examples
    (virtme-ng is started in graphical mode)
 ```
 
+ - Run virtme-ng inside a docker container:
+```
+   $ docker run -it ubuntu:22.04 /bin/bash
+   # apt update
+   # echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+   # apt install --yes git qemu-kvm udev iproute2 busybox-static \
+     coreutils python3-requests libvirt-clients kbd kmod file rsync zstd udev
+   # git clone --recursive https://github.com/arighi/virtme-ng.git
+   # ./virtme-ng/vng -r v6.6 -- uname -r
+   6.6.0-060600-generic
+```
+   See also: `.github/workflows/run.yml` as a practical example on how to use
+   virtme-ng inside docker.
+
 Implementation details
 ======================
 
@@ -388,6 +402,14 @@ Troubleshooting
    (keep in mind that virtme-ng will try to run snapd in a bare minimum system
    environment without systemd), if some snaps are not running try to disable
    apparmor, adding `--append="apparmor=0"` to the virtme-ng command line.
+
+ - Running virtme-ng instances inside docker: in case of failures/issues,
+   especially with stdin/stdout/stderr redirections, make sure that you have
+   `udev` installed in your docker image and run the following command before
+   using `vng`:
+```
+  $ udevadm trigger --subsystem-match --action=change
+```
 
 Contributing
 ============

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -600,8 +600,12 @@ class VirtioFS:
 
         # Export the whole root fs of the host, do not enable sandbox, otherwise we
         # would get permission errors.
+        if not verbose:
+            stderr = "2>/dev/null"
+        else:
+            stderr = ""
         os.system(
-            f"{virtiofsd_path} --syslog --socket-path {self.sock} --shared-dir {path} --sandbox none &"
+            f"{virtiofsd_path} --syslog --socket-path {self.sock} --shared-dir {path} --sandbox none {stderr} &"
         )
         max_attempts = 5
         check_duration = 0.1
@@ -613,7 +617,8 @@ class VirtioFS:
             sleep(check_duration)
             check_duration *= 2
         else:
-            print("virtme-run: failed to start virtiofsd, fallback to 9p")
+            if verbose:
+                sys.stderr.write("virtme-run: failed to start virtiofsd, fallback to 9p")
             return False
         return True
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1168,6 +1168,12 @@ def do_it() -> int:
     if args.user:
         kernelargs.append("virtme_user=%s" % args.user)
 
+    # If we are running as root on the host pass this information to the guest
+    # (this can be useful to properly support running virtme-ng instances
+    # inside docker)
+    if os.geteuid() == 0:
+        kernelargs.append("virtme_root_user=1")
+
     initrdpath: Optional[str]
 
     if need_initramfs:

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -36,6 +36,13 @@ done
 # Setup kernel modules
 kver="`uname -r`"
 
+# Make sure to always have /lib/modules, otherwise we won't be able to
+# configure kmod support properly (this can happen in some container
+# environments, such as docker).
+if [[ ! -d /lib/modules ]]; then
+    mkdir -p /lib/modules
+fi
+
 if [[ -n "$virtme_root_mods" ]]; then
     # /lib/modules is already set up
     true
@@ -330,10 +337,12 @@ echo "                                                |___/ "
 echo "   kernel version: $(uname -mr)"
 echo ""
 
-# Set up a basic environment
-install -d -m 0755 /tmp/roothome
-export HOME=/tmp/roothome
-mount --bind /tmp/roothome /root
+# Set up a basic environment (unless virtme-ng is running as root on the host)
+if [[ ! -n "${virtme_root_user}" ]]; then
+    install -d -m 0755 /tmp/roothome
+    export HOME=/tmp/roothome
+    mount --bind /tmp/roothome /root
+fi
 
 # $XDG_RUNTIME_DIR defines the base directory relative to which user-specific
 # non-essential runtime files and other file objects (such as sockets, named

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -766,7 +766,7 @@ class KernelSource:
         else:
             self.virtme_param["overlay_rwdir"] = " ".join(
                 f"--overlay-rwdir {d}"
-                for d in ("/etc", "/home", "/opt", "/srv", "/usr", "/var")
+                for d in ("/etc", "/lib", "/home", "/opt", "/srv", "/usr", "/var")
             )
         # Add user-specified overlays.
         for item in args.overlay_rwdir:


### PR DESCRIPTION
Set of changes to properly support running virtme-ng instances inside docker instances.

This will open the possibility for many projects to use virtme-ng to run custom kernels inside containerized environments, such as github workflows.

This fixes issue #51.