### PR TITLE
virtme-ng: introduce NUMA support

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -281,6 +281,13 @@ def make_parser():
     )
 
     parser.add_argument(
+        "--numa",
+        metavar="MEM[,cpus=FIRST_CPU1[-LAST_CPU1]][,cpus=FIRST_CPU2[-LAST_CPU2]]...",
+        action="append",
+        help="Create NUMA nodes in the guest (this implicitly disables the microvm architecture)"
+    )
+
+    parser.add_argument(
         "--balloon",
         action="store_true",
         help="Allow the host to ask the guest to release memory",
@@ -879,6 +886,13 @@ class KernelSource:
         else:
             self.virtme_param["memory"] = "--memory " + args.memory
 
+    def _get_virtme_numa(self, args):
+        if args.numa is not None:
+            numa_str = " ".join([f"--numa {numa}" for numa in args.numa])
+            self.virtme_param["numa"] = numa_str
+        else:
+            self.virtme_param["numa"] = ""
+
     def _get_virtme_balloon(self, args):
         if args.balloon:
             self.virtme_param["balloon"] = "--balloon"
@@ -948,6 +962,7 @@ class KernelSource:
         self._get_virtme_append(args)
         self._get_virtme_cpus(args)
         self._get_virtme_memory(args)
+        self._get_virtme_numa(args)
         self._get_virtme_balloon(args)
         self._get_virtme_snaps(args)
         self._get_virtme_busybox(args)
@@ -982,6 +997,7 @@ class KernelSource:
             + f'{self.virtme_param["append"]} '
             + f'{self.virtme_param["cpus"]} '
             + f'{self.virtme_param["memory"]} '
+            + f'{self.virtme_param["numa"]} '
             + f'{self.virtme_param["balloon"]} '
             + f'{self.virtme_param["snaps"]} '
             + f'{self.virtme_param["busybox"]} '


### PR DESCRIPTION
Add the --numa option to create custom NUMA nodes inside the guest and assign virtual CPUs to them.

Syntax:

  --numa MEM[,cpus=FIRST_CPU1[-LAST_CPU1]][,cpus=FIRST_CPU2[-LAST_CPU2]]...

Examples:

 - a simple one with 2 NUMA nodes of 2G each:
$ vng -r -m 4G --numa 2G --numa 2G -- numactl -H
available: 2 nodes (0-1)
node 0 cpus: 0 1 2 3 4 5 6 7
node 0 size: 1971 MB
node 0 free: 1779 MB
node 1 cpus:
node 1 size: 1950 MB
node 1 free: 1924 MB
node distances:
node   0   1 
  0:  10  20 
  1:  20  10 

- a more complex one, with a 1GB node and 3GB node, each one with a different non-contiguous set of CPUs assigned:
 $ vng -r -m 4G --numa 1G,cpus=0-1,cpus=3 --numa 3G,cpus=2,cpus=4-7 -- numactl -H
available: 2 nodes (0-1)
node 0 cpus: 0 1 3
node 0 size: 1005 MB
node 0 free: 912 MB
node 1 cpus: 2 4 5 6 7
node 1 size: 2916 MB
node 1 free: 2760 MB
node distances:
node   0   1 
  0:  10  20 
  1:  20  10 


Keep in mind that using --numa automatically disables the microvm architecture (that doesn't expose NUMA information).

Also note that virtiofsd requires a memory backed NUMA node, so if some custom NUMA nodes are created virtiofs will use the first one of them, otherwise it will create a single NUMA node that maps all the memory (that was the previous behavior).

But this allows to use --numa and enable virtiofsd at the same time.

This implements the request from issue #56.