### PR TITLE
virtme-ng: channel the return code of a command to the host

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -260,6 +260,11 @@ if [[ -n "${user_cmd}" ]]; then
             /dev/virtio-ports/virtme.stderr     \
             /dev/virtio-ports/virtme.dev_stdout \
             /dev/virtio-ports/virtme.dev_stderr
+
+        if [ -e /dev/virtio-ports/virtme.ret ]; then
+            chown ${virtme_user}                \
+                /dev/virtio-ports/virtme.ret
+        fi
     fi
 
     # Fix /dev/stdout and /dev/stderr.
@@ -289,7 +294,13 @@ if [[ -n "${user_cmd}" ]]; then
         else
             setsid bash /tmp/.virtme-script </dev/virtio-ports/virtme.stdin >/dev/virtio-ports/virtme.stdout 2>/dev/virtio-ports/virtme.stderr
         fi
-        log "script returned $?"
+	ret=$?
+        log "script returned {$ret}"
+
+        # Channel exit code to the host.
+        if [ -e /dev/virtio-ports/virtme.ret ]; then
+            echo ${ret} > /dev/virtio-ports/virtme.ret
+        fi
 
         # Hmm.  We should expose the return value somehow.
         sync

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1102,8 +1102,7 @@ def clean(kern_source, args):
 
 def run(kern_source, args):
     """Run the kernel."""
-    kern_source.run(args)
-    return True
+    return kern_source.run(args)
 
 
 @spinner_decorator(message="🐞 generating memory dump")
@@ -1137,12 +1136,17 @@ def do_it() -> int:
             if not args.skip_config:
                 config(kern_source, args)
                 if args.kconfig:
-                    return
+                    return 0
             make(kern_source, args)
         else:
-            run(kern_source, args)
+            try:
+                run(kern_source, args)
+                return 0
+            except CalledProcessError as exc:
+                return exc.returncode
     except CalledProcessError as exc:
         raise SilentError() from exc
+    return 0
 
 
 def main() -> int:


### PR DESCRIPTION
Send the return code of the command executed inside the guest to the host.

This allows to run commands inside a guest and give users the impression that they are running on the host.

Examples:

  $ vng -r -- true && echo OK || echo ERROR: $?
  OK
  $ vng -r -- false && echo OK || echo ERROR: $?
  ERROR: 1
  $ vng -r -- exit 22 && echo OK || echo ERROR: $?
  ERROR: 22

This feature is particularly useful for automation/CI, since it easily allows to check the return code of a script executed inside virtme-ng as if it was running directly on the host.

This fixes issue #48.