### PR TITLE
virtme-configkernel: disable lockdep by default

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -154,7 +154,6 @@ _GENERIC_CONFIG_OPTIONAL = [
     "CONFIG_UPROBES=y",
     "CONFIG_UPROBE_EVENTS=y",
     "CONFIG_DEBUG_FS=y",
-    "CONFIG_PROVE_LOCKING=y",
     "# Graphics support",
     "CONFIG_DRM=y",
     "CONFIG_DRM_VIRTIO_GPU=y",


### PR DESCRIPTION
Sort of an "RFC" posting. We (netdev) use vng to run networking tests in two flavors - normal and debug. I was surprised to see lockdep splats in the "normal" one.


Commit cd3c35c73624 ("virtme-configkernel: enable lockdep by default") enabled lockdep, and no doubt lockdep is a useful tool. But it's a bit surprising that lockdep is enabled on a normal vng build. I would have expected "vanilla vng build" to be pretty close to kvm_guest.config. lockdep slows down the kernel, eats memory and is not exactly free of false positives.