### PR TITLE
virtme: let user disable KVM accel easily

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -23,8 +23,9 @@ class Arch:
         return False
 
     @staticmethod
-    def qemuargs(is_native) -> List[str]:
+    def qemuargs(is_native, use_kvm) -> List[str]:
         _ = is_native
+        _ = use_kvm
         return []
 
     @staticmethod
@@ -77,8 +78,8 @@ class Arch:
 
 class Arch_unknown(Arch):
     @staticmethod
-    def qemuargs(is_native):
-        return Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        return Arch.qemuargs(is_native, use_kvm)
 
 
 class Arch_x86(Arch):
@@ -93,13 +94,13 @@ class Arch_x86(Arch):
         return True
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
 
         # Add a watchdog.  This is useful for testing.
         ret.extend(["-device", "i6300esb,id=watchdog0"])
 
-        if is_native and os.access("/dev/kvm", os.R_OK):
+        if is_native and use_kvm:
             # If we're likely to use KVM, request a full-featured CPU.
             # (NB: if KVM fails, this will cause problems.  We should probe.)
             ret.extend(["-cpu", "host"])  # We can't migrate regardless.
@@ -176,13 +177,13 @@ class Arch_microvm(Arch_x86):
         ]
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
 
         # Use microvm architecture for faster boot
         ret.extend(["-M", "microvm,accel=kvm,pcie=on"])
 
-        if is_native and os.access("/dev/kvm", os.R_OK):
+        if is_native and use_kvm:
             # If we're likely to use KVM, request a full-featured CPU.
             # (NB: if KVM fails, this will cause problems.  We should probe.)
             ret.extend(["-cpu", "host"])  # We can't migrate regardless.
@@ -197,8 +198,8 @@ class Arch_arm(Arch):
         self.defconfig_target = "vexpress_defconfig"
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
 
         # Emulate a vexpress-a15.
         ret.extend(["-M", "vexpress-a15"])
@@ -247,8 +248,8 @@ class Arch_aarch64(Arch):
         self.gccname = "aarch64"
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
 
         if is_native:
             ret.extend(["-M", "virt,gic-version=host"])
@@ -289,8 +290,8 @@ class Arch_ppc(Arch):
         self.gccname = "powerpc64le"
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
         ret.extend(["-M", "pseries"])
 
         return ret
@@ -324,8 +325,8 @@ class Arch_riscv64(Arch):
         return True
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
         ret.extend(["-machine", "virt"])
         ret.extend(["-bios", "default"])
 
@@ -349,8 +350,8 @@ class Arch_sparc64(Arch):
         self.gccname = "sparc64"
 
     @staticmethod
-    def qemuargs(is_native):
-        return Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        return Arch.qemuargs(is_native, use_kvm)
 
     def kimg_path(self):
         return "arch/sparc/boot/image"
@@ -374,8 +375,8 @@ class Arch_s390x(Arch):
         return "virtio-%s-ccw" % virtiotype
 
     @staticmethod
-    def qemuargs(is_native):
-        ret = Arch.qemuargs(is_native)
+    def qemuargs(is_native, use_kvm):
+        ret = Arch.qemuargs(is_native, use_kvm)
 
         # Ask for the latest version of s390-ccw
         ret.extend(["-M", "s390-ccw-virtio"])

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -963,11 +963,12 @@ def do_it() -> int:
         kernelargs.append("virtme_rw_overlay%d=%s" % (i, d))
 
     # Turn on KVM if available
-    if is_native and can_use_kvm():
+    kvm_ok = can_use_kvm()
+    if is_native and kvm_ok:
         qemuargs.extend(["-machine", "accel=kvm:tcg"])
 
     # Add architecture-specific options
-    qemuargs.extend(arch.qemuargs(is_native))
+    qemuargs.extend(arch.qemuargs(is_native, kvm_ok))
 
     # Set up / override baseline devices
     qemuargs.extend(["-parallel", "none"])

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -234,6 +234,11 @@ def make_parser() -> argparse.ArgumentParser:
         help='Avoid using the "microvm" QEMU architecture (only on x86_64)',
     )
     g.add_argument(
+        "--disable-kvm",
+        action="store_true",
+        help='Avoid using hardware virtualization / KVM',
+    )
+    g.add_argument(
         "--force-initramfs",
         action="store_true",
         help="Use an initramfs even if unnecessary",
@@ -720,7 +725,9 @@ def sanitize_disk_args(func: str, arg: str) -> Tuple[str, str]:
     return name, fn
 
 
-def can_use_kvm():
+def can_use_kvm(args):
+    if args.disable_kvm:
+        return False
     if not os.path.exists("/dev/kvm"):
         return False
     try:
@@ -733,7 +740,7 @@ def can_use_kvm():
 
 
 def can_use_microvm(args):
-    return not args.disable_microvm and not args.numa and args.arch == "x86_64" and can_use_kvm()
+    return not args.disable_microvm and not args.numa and args.arch == "x86_64" and can_use_kvm(args)
 
 
 def has_read_acl(username, file_path):
@@ -963,7 +970,7 @@ def do_it() -> int:
         kernelargs.append("virtme_rw_overlay%d=%s" % (i, d))
 
     # Turn on KVM if available
-    kvm_ok = can_use_kvm()
+    kvm_ok = can_use_kvm(args)
     if is_native and kvm_ok:
         qemuargs.extend(["-machine", "accel=kvm:tcg"])
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -236,6 +236,12 @@ def make_parser():
     )
 
     parser.add_argument(
+        "--disable-kvm",
+        action="store_true",
+        help='Avoid using hardware virtualization / KVM',
+    )
+
+    parser.add_argument(
         "--cwd",
         action="store",
         help="Change guest working directory "
@@ -855,6 +861,12 @@ class KernelSource:
         else:
             self.virtme_param["disable_microvm"] = ""
 
+    def _get_virtme_disable_kvm(self, args):
+        if args.disable_kvm:
+            self.virtme_param["disable_kvm"] = "--disable-kvm"
+        else:
+            self.virtme_param["disable_kvm"] = ""
+
     def _get_virtme_9p(self, args):
         if args.force_9p:
             self.virtme_param["force_9p"] = "--force-9p"
@@ -965,6 +977,7 @@ class KernelSource:
         self._get_virtme_disk(args)
         self._get_virtme_sound(args)
         self._get_virtme_disable_microvm(args)
+        self._get_virtme_disable_kvm(args)
         self._get_virtme_9p(args)
         self._get_virtme_initramfs(args)
         self._get_virtme_graphics(args)
@@ -1000,6 +1013,7 @@ class KernelSource:
             + f'{self.virtme_param["disk"]} '
             + f'{self.virtme_param["sound"]} '
             + f'{self.virtme_param["disable_microvm"]} '
+            + f'{self.virtme_param["disable_kvm"]} '
             + f'{self.virtme_param["force_9p"]} '
             + f'{self.virtme_param["force_initramfs"]} '
             + f'{self.virtme_param["graphics"]} '


### PR DESCRIPTION
Add a --disable-kvm switch. Some of our testers run without KVM support (nested virt) and developers struggle to repro similarly sluggish execution for their tests. Allow turning KVM off with a single switch even when it's usable.