### PR TITLE
virtme-ng: redirect kernel log to stderr in interactive mode

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -124,7 +124,7 @@ class Arch_x86(Arch):
 
     @staticmethod
     def serial_console_args():
-        return ["console=ttyS0"]
+        return ["virtme_console=ttyS0"]
 
     @staticmethod
     def config_base():
@@ -225,7 +225,7 @@ class Arch_arm(Arch):
 
     @staticmethod
     def serial_console_args():
-        return ["console=ttyAMA0"]
+        return ["virtme_console=ttyAMA0"]
 
     def kimg_path(self):
         return "arch/arm/boot/zImage"
@@ -274,7 +274,7 @@ class Arch_aarch64(Arch):
 
     @staticmethod
     def serial_console_args():
-        return ["console=ttyAMA0"]
+        return ["virtme_console=ttyAMA0"]
 
     def kimg_path(self):
         return "arch/arm64/boot/Image"
@@ -334,7 +334,7 @@ class Arch_riscv64(Arch):
 
     @staticmethod
     def serial_console_args():
-        return ["console=ttyS0"]
+        return ["virtme_console=ttyS0"]
 
     def kimg_path(self):
         return "arch/riscv/boot/Image"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -310,7 +310,11 @@ if [[ -n "${user_cmd}" ]]; then
 fi
 
 # Figure out what the main console is
-consdev="`grep ' ... (.C' /proc/consoles  |cut -d' ' -f1`"
+if [[ -n "${virtme_console}" ]]; then
+    consdev=${virtme_console}
+else
+    consdev="`grep ' ... (.C' /proc/consoles  |cut -d' ' -f1`"
+fi
 if [[ -z "$consdev" ]]; then
     log "can't deduce console device"
     exec bash --login  # At least try to be helpful
@@ -334,6 +338,10 @@ if [[ ! -e "/dev/$consdev" ]]; then
     log "/dev/$consdev doesn't exist."
     exec bash --login
 fi
+
+# Redirect current stdout/stderr to consdev
+exec 1>/dev/${consdev}
+exec 2>&1
 
 # Parameters that start with virtme_ shouldn't pollute the environment
 for p in "${!virtme_@}"; do export -n "$p"; done


### PR DESCRIPTION
Redirect kernel messages to stderr when running in interactive mode, similar to what we do in command/script mode.

In this way it is possible, for example, to save kernel logs to a file even when running in interactive mode, such as:

 $ vng -vr 2>/tmp/kernel.log

NOTE: unfortunately we can't redirect early boot kernel messages, earlyprintk doesn't seem to work with virconsole devices. So, early messages will be still sent to stdout, in this way we don't break the old behavior.

This addresses discussion #60.