### PR TITLE
virtme: fix traceback with --kdir when .config doesn't exist

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -390,6 +390,7 @@ def get_kernel_version(path):
 
 def find_kernel_and_mods(arch, args) -> Kernel:
     kernel = Kernel()
+    kernel.config = None
 
     kernel.use_root_mods = False
     if args.installed_kernel is not None:


### PR DESCRIPTION
Reproducer:
```
$ mkdir -p testdir/arch/x86/boot
$ touch testdir/arch/x86/boot/bzImage
$ virtme-run --kdir testdir
Traceback (most recent call last):
  File "/usr/bin/virtme-run", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/virtme/commands/run.py", line 1388, in main
    return do_it()
           ^^^^^^^
  File "/usr/lib/python3.12/site-packages/virtme/commands/run.py", line 803, in do_it
    kernel = find_kernel_and_mods(arch, args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/virtme/commands/run.py", line 486, in find_kernel_and_mods
    kernel.config is not None
    ^^^^^^^^^^^^^
AttributeError: 'Kernel' object has no attribute 'config'
```

Fix the above by initializing kernel.config right away.