### PR TITLE
setup.py: fix logic around the virtme_ng_init submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,16 @@ if os.path.exists(".config"):
             key, value = line.strip().split("=")
             os.environ[key] = value
 
+# Global variables to store custom build options (as env variables)
+build_virtme_ng_init = int(os.environ.get("BUILD_VIRTME_NG_INIT", 0))
+
 # Make sure virtme-ng-init submodule has been cloned
-if not os.listdir("virtme_ng_init"):
+if build_virtme_ng_init and not os.path.exists("virtme_ng_init"):
     sys.stderr.write("WARNING: virtme-ng-init submoule not available, trying to clone it\n")
     check_call("git submodule update --init --recursive", shell=True)
 
 # Always include standard site-packages to PYTHONPATH
 os.environ['PYTHONPATH'] = sysconfig.get_paths()['purelib']
-
-# Global variables to store custom build options (as env variables)
-build_virtme_ng_init = int(os.environ.get("BUILD_VIRTME_NG_INIT", 0))
 
 
 def is_arm_32bit():


### PR DESCRIPTION
First, os.listdir("virtme_ng_init") throws an exception when the directory doesn't exist, which is not desirable. Replace it with os.path.exists(), which does the right thing.

Second, it only makes sense to check for the virtme_ng_init submodule when BUILD_VIRTME_NG_INIT != 0, so add it to the conditional.