### PR TITLE
init: allow to mount legacy cgroupfs (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,19 @@ Troubleshooting
   $ udevadm trigger --subsystem-match --action=change
 ```
 
+ - To mount the legacy cgroup filesystem (v1) layout, add
+   `SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1` to the kernel boot options:
+```
+$ vng -r --append "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1" -- 'df -T /sys/fs/cgroup/*'
+Filesystem     Type   1K-blocks  Used Available Use% Mounted on
+blkio          cgroup         0     0         0    - /sys/fs/cgroup/blkio
+cpu            cgroup         0     0         0    - /sys/fs/cgroup/cpu
+cpuacct        cgroup         0     0         0    - /sys/fs/cgroup/cpuacct
+devices        cgroup         0     0         0    - /sys/fs/cgroup/devices
+memory         cgroup         0     0         0    - /sys/fs/cgroup/memory
+pids           cgroup         0     0         0    - /sys/fs/cgroup/pids
+```
+
 Contributing
 ============
 

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -188,7 +188,21 @@ mount -t tracefs tracefs /sys/kernel/tracing &>/dev/null
 mount -t securityfs securityfs /sys/kernel/security &>/dev/null
 
 # Set up cgroup mount points (mount cgroupv2 hierarchy by default)
-mount -t cgroup2 cgroup2 /sys/fs/cgroup
+#
+# If SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 is passed we can mimic systemd's
+# behavior and mount the legacy cgroup v1 layout.
+if cat /proc/cmdline |grep -q -E '(^| )SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1($| )'; then
+    mount -t tmpfs cgroup /sys/fs/cgroup
+    sybsys=(cpu cpuacct blkio memory devices pids)
+    for s in "${sybsys[@]}"; do
+        mkdir -p "/sys/fs/cgroup/${s}"
+        # Don't treat failure as critical here, since the kernel may not
+        # support all the legacy cgroups.
+        mount -t cgroup "${s}" -o "${s}" "/sys/fs/cgroup/${s}" || true
+    done
+else
+    mount -t cgroup2 cgroup2 /sys/fs/cgroup
+fi
 
 # Set up filesystems that live in /dev
 mkdir -p -m 0755 /dev/shm /dev/pts


### PR DESCRIPTION
Allow to mount legacy cgroup when SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 is passed to the kernel boot command options.

This mimics systemd's behavior, as specified in the systemd documentation:
```
CHANGES WITH 256 in spe:
...
    * Support for cgroup v1 ('legacy' and 'hybrid' hierarchies) is now
      considered obsolete and systemd by default will refuse to boot under it.
      To forcibly reenable cgroup v1 support, SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
      must be set on kernel command line.
...
```

Moreover, with cgroup v1, only try to mount the same legacy cgroup subsystems supported by systemd (also from the systemd doc):
```
* on cgroup v1: `cpu`, `cpuacct`, `blkio`, `memory`, `devices`, `pids`
```

This was discussed in #84.