### PR TITLE
init: set the HOME env var if root

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -388,6 +388,8 @@ if [[ ! -n "${virtme_root_user}" ]]; then
     install -d -m 0755 /tmp/roothome
     export HOME=/tmp/roothome
     mount --bind /tmp/roothome /root
+else
+    export HOME=/root
 fi
 
 # $XDG_RUNTIME_DIR defines the base directory relative to which user-specific


### PR DESCRIPTION
When virtme-ng was running as root, the HOME dir was set to '/'.

Now it is set to '/root', the expected value.

Fixes: bcd99d9 ("virtme-init: docker host support")

Note: this PR depends on https://github.com/arighi/virtme-ng-init/pull/7