### PR TITLE
vng: override kconfig with '--force'

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -408,7 +408,8 @@ def make_parser():
         "--force",
         action="store_true",
         help="Force reset git repository to target branch or commit "
-        "(warning: this may drop uncommitted changes)",
+        "(warning: this may drop uncommitted changes), "
+        "and force kernel config override",
     )
 
     parser.add_argument(
@@ -565,7 +566,9 @@ class KernelSource:
     def config(self, args):
         """Perform a make config operation on a kernel source directory."""
         arch = args.arch
-        cmd = "virtme-configkernel --defconfig --no-update"
+        cmd = "virtme-configkernel --defconfig"
+        if not args.force:
+            cmd += " --no-update"
         if arch is not None:
             if arch not in ARCH_MAPPING:
                 arg_fail(f"unsupported architecture: {arch}")

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -157,7 +157,7 @@ def make_parser():
         "--kconfig",
         "-k",
         action="store_true",
-        help="Only generate the kernel .config without building/running anything",
+        help="Only override the kernel .config without building/running anything",
     )
 
     parser.add_argument(
@@ -567,7 +567,7 @@ class KernelSource:
         """Perform a make config operation on a kernel source directory."""
         arch = args.arch
         cmd = "virtme-configkernel --defconfig"
-        if not args.force:
+        if not args.force and not args.kconfig:
             cmd += " --no-update"
         if arch is not None:
             if arch not in ARCH_MAPPING:


### PR DESCRIPTION
By default, `vng --build` and `--kconfig` will not modify existing kconfig, even if new kconfig files are given. The idea is to let people modifying them manually.

It is now possible to force the modification of the kconfig by using '--force'.

Suggested-by: @arighi 