### PR TITLE
readme: docker: --privileged and virtiofsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Examples
 
  - Run virtme-ng inside a docker container:
 ```
-   $ docker run -it ubuntu:22.04 /bin/bash
+   $ docker run -it --privileged ubuntu:22.04 /bin/bash
    # apt update
    # echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
    # apt install --yes git qemu-kvm udev iproute2 busybox-static \

--- a/README.md
+++ b/README.md
@@ -320,11 +320,11 @@ Examples
 
  - Run virtme-ng inside a docker container:
 ```
-   $ docker run -it --privileged ubuntu:22.04 /bin/bash
+   $ docker run -it --privileged ubuntu:23.10 /bin/bash
    # apt update
    # echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
    # apt install --yes git qemu-kvm udev iproute2 busybox-static \
-     coreutils python3-requests libvirt-clients kbd kmod file rsync zstd udev
+     coreutils python3-requests libvirt-clients kbd kmod file rsync zstd virtiofsd
    # git clone --recursive https://github.com/arighi/virtme-ng.git
    # ./virtme-ng/vng -r v6.6 -- uname -r
    6.6.0-060600-generic


### PR DESCRIPTION
`virtme` will fallback to `tcg` is KVM cannot be used. That's a shame and it might not be clear that by default, the container will not have access to KVM. An easy way is to launch `docker` with `--privileged`.

While at it, also recommend using Ubuntu 23.10 with virtiofsd.