### PR TITLE
qemu: remove useless '-serial none' arg

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1001,7 +1001,6 @@ def do_it() -> int:
 
     if args.graphics is None and not args.script_sh and not args.script_exec:
         qemuargs.extend(["-echr", "1"])
-        qemuargs.extend(["-serial", "none"])
 
         if args.verbose:
             # Check if we have permission to access the current stderr.


### PR DESCRIPTION
When not using the `--graphics` mode, or without the script options, QEmu was always launched with:

    -serial none -serial chardev:console

`-serial none` means "don't allocate this serial device". Here, it is directly overridden by another serial. Best not to declare '-serial none' then.

Since QEmu 8.2.2, having `-serial none -serial <something>` is no longer supported, and it is then recommended to remove the unnecessary `-serial none` [1]. It continues to work on previous versions (tested on 8.2.1).

Reported-by: @tehcaster (and others)
Closes: #97
Link: https://lore.kernel.org/qemu-devel/20240122163607.459769-2-peter.maydell@linaro.org/ [1]
Suggested-by: @ishitatsuyuki

Note: I'm not using QEmu 8.2.2 yet, but a few people reported having this issue with it, and a solution has already been suggested. So why not doing the modification in the code for everyone :)