### PR TITLE
Add additional path for virtiofsd executable

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -587,6 +587,7 @@ class VirtioFS:
             f"{self.guest_tools_path}/bin/virtiofsd",
             which("virtiofsd"),
             "/usr/libexec/virtiofsd",
+            "/usr/lib/virtiofsd",
             "/usr/lib/qemu/virtiofsd",
         )
         for path in possible_paths:


### PR DESCRIPTION
The Arch Linux qemu-base package depends on the [virtiofsd package](https://archlinux.org/packages/extra/x86_64/virtiofsd/), which installs the binary @ /usr/lib/virtiofsd. This PR adds that path to the possible paths.

I noticed this because qemu appears to use a lot of CPU without virtfiosd, which was making my arch laptop run pretty hot.