### PR TITLE
config: avoid accidentally specifying invalid cross-compile

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -282,7 +282,7 @@ def do_it():
     linuxname = shlex.quote(arch.linuxname)
     archargs = [f"ARCH={linuxname}"]
 
-    if shutil.which(f"{arch.gccname}-linux-gnu-gcc"):
+    if shutil.which(f"{arch.gccname}-linux-gnu-gcc") and arch.gccname != uname.machine:
         gccname = shlex.quote(f"{arch.gccname}-linux-gnu-")
         archargs.append(f"CROSS_COMPILE={gccname}")
 


### PR DESCRIPTION
On x86-64 Arch Linux the x86_64-linux-gnu-gcc binary exists and is owned by the gcc package. Since this matches the host arch, this means the heuristic that the existence of such a binary implies that this is a cross-compile is broken.

In addition, Arch linux (for some reason) does not bundle x86_64-linux-gnu-ld so this actually breaks the config generation altogether.

Be a little more cautious and do not specify cross-compilation if we know for sure the gcc prefix refers to the host.