### PR TITLE
virtme: default to q35 architecture when kvm is not available

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -104,6 +104,8 @@ class Arch_x86(Arch):
             # If we're likely to use KVM, request a full-featured CPU.
             # (NB: if KVM fails, this will cause problems.  We should probe.)
             ret.extend(["-cpu", "host"])  # We can't migrate regardless.
+        else:
+            ret.extend(["-machine", "q35"])
 
         return ret
 


### PR DESCRIPTION
In systems where kvm acceleration cannot be used (e.g, within nested virtualization environments, such as cloud computing, containers, etc.), we might encounter increased boot-time delays resulting from ACPI initialization.

This should be improved if this patch lands upstream: https://lore.kernel.org/qemu-devel/20240417135608.2613586-1-ribalda@chromium.org/T/#u

Meanwhile, it makes sense to consider using the q35 architecture in qemu, instead of the default, when KVM acceleration is not available or unusable, in order to mitigate the ACPI initialization slowdown.

Running some experiments with kvm disabled, also adding '-cpu max' to the equation, and measuring the boot time of multiple virtme-ng runs, shows the following result (average of 10 runs):

		     machine
              +----------------
              | default     q35
     ---------+----------------
cpu  |default |     13s     11s
     |max     |     15s     14s

Similar results can be obtained with different hardware and different kernel configs.

Therefore, given that the main goal of virtme-ng is to optimize boot time, it makes sense to fallback to the q35 machine and default cpu settings when kvm is unavailable.

Keep in mind that it is always possible to override this setting adding using the options `--qemu-opts="-machine <MACHINE_TYPE>"`, for example:

  vng ... --qemu-opts="-machine pc" -- uname -r