### PR TITLE
github: new test with KVM support

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,3 +24,16 @@ jobs:
 
       # Run `uname -r` using a vanilla v6.6 kernel
       - run: ./vng -r v6.6 -- uname -r
+
+      # Setup KVM support
+      - name: "KVM support"
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Re-run with KVM support
+      - name: "Check KVM support"
+        run: |
+          clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
+          [ "$(./vng -r v6.6 -- cat "${clocksource}")" = "kvm-clock" ]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,14 @@ Requirements
      you should be on bare metal with hardware virtualization (VT-x or SVM)
      enabled or in a VM that supports nested virtualization.  On some Linux
      distributions, you may need to be a member of the "kvm" group.  Using
-     VirtualBox or most VPS providers will fall back to emulation.
+     VirtualBox or most VPS providers will fall back to emulation. If you are
+     using GitHub Actions, KVM support is supported on "larger Linux runners" --
+     which is [now](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/)
+     the default runner -- but it has to be
+     [manually enabled](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/),
+     see how it is used in [our tests](.github/workflows/run.yml) or
+     [here](https://github.com/multipath-tcp/mptcp_net-next/commit/677b5ecd223c)
+     with Docker.
 
  * Depending on the options you use, you may need a statically linked `busybox`
    binary somewhere in your path.


### PR DESCRIPTION
KVM is supported on "larger Linux runners" ...

  https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/

... which is the default runner for public GitHub repos since January:

  https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

I don't think this is well known, and it needs to be manually enabled, so it might be good to show an example for those who are interested in that.

*****

The announcement of the v1.24 was the trigger for this PR. When I read it the first time, it sounded that KVM acceleration could be seen in containers and GitHub Actions, while it is the setup I use for MPTCP (GitHub Actions + Docker) :)