### PR TITLE
virtme: make sure RTC is enabled with microvm

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -183,7 +183,7 @@ class Arch_microvm(Arch_x86):
         ret = Arch.qemuargs(is_native, use_kvm)
 
         # Use microvm architecture for faster boot
-        ret.extend(["-M", "microvm,accel=kvm,pcie=on"])
+        ret.extend(["-M", "microvm,accel=kvm,pcie=on,rtc=on"])
 
         if is_native and use_kvm:
             # If we're likely to use KVM, request a full-featured CPU.


### PR DESCRIPTION
If RTC is not enabled with the microvm architecture the kernel may end up wasting time to probe the RTC during boot:

 [    2.477821] rtc_cmos rtc_cmos: broken or not accessible
 [    2.478041] probe of rtc_cmos returned 6 after 1108478 usecs
 [    2.478070] initcall cmos_init+0x0/0x90 returned -19 after 1108517 usecs

Make sure to enable the RTC to avoid this unnecessary failure and speed up boot time.

A simple `vng -- uname -r` goes from ~3s to ~0.9s with this change applied using a 6.9 kernel.