### PR TITLE
setup.py: silent lint error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ class BuildPy(build_py):
                 cwd="virtme_ng_init",
             )
         # Generate bash autocompletion scripts
+        completion_command = ''
         if which("register-python-argcomplete"):
             completion_command = "register-python-argcomplete"
         elif which("register-python-argcomplete3"):

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -288,6 +288,7 @@ def do_it():
 
     maketarget: Optional[str]
 
+    updatetarget = ""
     if args.allnoconfig:
         maketarget = "allnoconfig"
         updatetarget = "syncconfig"


### PR DESCRIPTION
Silent the following lint errors that seems to break CI:

 setup.py:84:19: E0606: Possibly using variable 'completion_command' before assignment (possibly-used-before-assignment)
virtme/commands/configkernel.py:338:53: E0606: Possibly using variable 'updatetarget' before assignment (possibly-used-before-assignment)