### PR TITLE
virtme-ng: export real /tmp to guest

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -447,11 +447,6 @@ def find_kernel_and_mods(arch, args) -> Kernel:
             # the modules, just rely on /lib/modules in the target rootfs.
             if root_dir == "/" or args.root != '/':
                 kernel.use_root_mods = True
-            elif root_dir.startswith("/tmp"):
-                sys.stderr.write(
-                    "\nWarning: /tmp is hidden inside the guest, "
-                    + "kernel modules won't be supported at runtime unless you move them somewhere else.\n\n"
-                )
             kernel.moddir = f"{root_dir}/lib/modules/{kver}"
             if not os.path.exists(kernel.moddir):
                 kernel.modfiles = []

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -20,14 +20,13 @@ mount -t proc -o nosuid,noexec,nodev proc /proc/
 mount -t sysfs -o nosuid,noexec,nodev sys /sys/
 
 # Mount tmpfs dirs
-mount -t tmpfs tmpfs /tmp/
 mount -t tmpfs run /run/
 
 # Setup rw filesystem overlays
 for tag in "${!virtme_rw_overlay@}"; do
     dir="${!tag}"
-    upperdir="/tmp/$tag/upper"
-    workdir="/tmp/$tag/work"
+    upperdir="/run/tmp/$tag/upper"
+    workdir="/run/tmp/$tag/work"
     mkdir -p "$upperdir" "$workdir"
     mnt_opts="xino=off,lowerdir=$dir,upperdir=$upperdir,workdir=$workdir"
     mount -t overlay -o "${mnt_opts}" "${tag}" "${dir}" &

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -798,7 +798,7 @@ class KernelSource:
         else:
             self.virtme_param["overlay_rwdir"] = " ".join(
                 f"--overlay-rwdir {d}"
-                for d in ("/etc", "/lib", "/home", "/opt", "/srv", "/usr", "/var")
+                for d in ("/etc", "/lib", "/home", "/opt", "/srv", "/usr", "/var", "/tmp")
             )
         # Add user-specified overlays.
         for item in args.overlay_rwdir:


### PR DESCRIPTION
Use /run to store overlays instead of /tmp.

Require https://github.com/arighi/virtme-ng-init/pull/9 to be merged to keep virtme-ng-init functional.