### PR TITLE
virtme-ng: provide a man page for vng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 .mypy_cache
 virtme-ng-prompt
 vng-prompt
+vng.1
 virtme_ng.egg-info/
 .pybuild/
 debian/virtme-ng/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 argcomplete
+argparse-manpage
 requests

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,18 @@ class LintCommand(Command):
             sys.exit(1)
 
 
+man_command = f"""
+argparse-manpage \
+  --pyfile ./virtme_ng/run.py --function make_parser \
+  --prog vng --version v{VERSION} \
+  --author "virtme-ng is written by Andrea Righi <andrea.righi@canonical.com>" \
+  --author "Based on virtme by Andy Lutomirski <luto@kernel.org>" \
+  --project-name virtme-ng --manual-title virtme-ng \
+  --description "Quickly run kernels inside a virtualized snapshot of your live system" \
+  --url https://github.com/arighi/virtme-ng > vng.1
+"""
+
+
 class BuildPy(build_py):
     def run(self):
         print(f"BUILD_VIRTME_NG_INIT: {build_virtme_ng_init}")
@@ -73,6 +85,12 @@ class BuildPy(build_py):
                 ["strip", "-s", "../virtme/guest/bin/virtme-ng-init"],
                 cwd="virtme_ng_init",
             )
+        # Generate manpage
+        if which('argparse-manpage'):
+            env = os.environ.copy()
+            env["PYTHONPATH"] = os.path.dirname(os.path.abspath(__file__))
+            check_call(man_command, shell=True, env=env)
+
         # Generate bash autocompletion scripts
         completion_command = ''
         if which("register-python-argcomplete"):
@@ -157,6 +175,7 @@ setup(
         ("/etc", ["cfg/virtme-ng.conf"]),
         ("/usr/share/bash-completion/completions", ["virtme-ng-prompt"]),
         ("/usr/share/bash-completion/completions", ["vng-prompt"]),
+        ("/usr/share/man/man1", ["vng.1"]),
     ],
     scripts=[
         "bin/virtme-prep-kdir-mods",

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -77,7 +77,30 @@ def make_parser():
     """Main virtme-ng command line parser."""
 
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
         description="Build and run kernels inside a virtualized snapshot of your live system",
+        epilog="""\
+virtme-ng is a tool that allows to easily and quickly recompile and test a
+Linux kernel, starting from the source code. It allows to re‐ compile  the
+kernel in a few minutes (rather than hours), then the kernel is automatically
+started in a virtualized environment that is an exact copy-on-write copy of
+your live system, which means that any changes made to the virtualized
+environment do not affect the host system.
+
+In order to do this, a minimal config is produced (with the bare minimum
+support to test the kernel inside qemu), then the selected ker‐ nel is
+automatically built and started inside qemu, using the filesystem of the host
+as a copy-on-write snapshot.
+
+This means that you can safely destroy the entire filesystem, crash the kernel,
+etc. without affecting the host.
+
+NOTE: kernels produced with virtme-ng are lacking lots of features, in order to
+reduce the build time to the minimum and still provide you a usable kernel
+capable of running your tests and experiments.
+
+virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
+""",
     )
     parser.add_argument(
         "--version", "-V", action="version", version=f"virtme-ng {VERSION}"


### PR DESCRIPTION
Automatically generate a manpage via argparse-manpage.

We can improve the content of the man page later in the future, but for now it has all the basic information about the command line options and their description, that can be useful when it's not possible to access the main README.md on the github page.

This closes issue #89.