### PR TITLE
virtme-ng: fix virtiofsd search path on openSUSE

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -582,6 +582,7 @@ class VirtioFS:
             f"{self.guest_tools_path}/bin/virtiofsd",
             which("virtiofsd"),
             "/usr/libexec/virtiofsd",
+            "/usr/lib/virtiofsd/virtiofsd",
             "/usr/lib/virtiofsd",
             "/usr/lib/qemu/virtiofsd",
         )


### PR DESCRIPTION
On openSUSE based systems, virtiofsd is in /usr/lib/virtiofsd/virtiofsd.

Fix the search path for it.