### PR TITLE
vng: introduce kernel debugging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,25 @@ Examples
    >>> (volatile unsigned long)4294675464
 ```
 
+ - Attach a gdb session to a running instance started with `--debug`:
+```
+   # Start the vng instance in debug mode
+   $ vng --debug
+
+   # In a separate terminal run the following command to attach the gdb session:
+   $ vng --gdb
+   kernel version = 6.9.0-virtme
+   Reading symbols from vmlinux...
+   Remote debugging using localhost:1234
+   native_irq_disable () at ./arch/x86/include/asm/irqflags.h:37
+   37		asm volatile("cli": : :"memory");
+   (gdb)
+
+   # NOTE: a vmlinux must be present in the current working directory in order
+   # to resolve symbols, otherwise vng # will automatically search for a
+   # vmlinux available in the system.
+```
+
  - Run virtme-ng inside a docker container:
 ```
    $ docker run -it --privileged ubuntu:23.10 /bin/bash

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -928,15 +928,15 @@ class KernelSource:
             self.virtme_param["verbose"] = ""
 
     def _get_virtme_append(self, args):
+        append = []
         if args.append is not None:
-            append = []
             for item in args.append:
                 split_items = item.split()
                 for split_item in split_items:
                     append.append("-a " + split_item)
-            self.virtme_param["append"] = " ".join(append)
-        else:
-            self.virtme_param["append"] = ""
+        if args.debug:
+            append.append("-a nokaslr")
+        self.virtme_param["append"] = " ".join(append)
 
     def _get_virtme_memory(self, args):
         if args.memory is None:

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -10,6 +10,7 @@ import sys
 import socket
 import shutil
 import json
+import signal
 import tempfile
 from subprocess import (
     check_call,
@@ -164,6 +165,12 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "--no-virtme-ng-init",
         action="store_true",
         help="Fallback to the bash virtme-init (useful for debugging/development)",
+    )
+
+    parser.add_argument(
+        "--gdb",
+        action="store_true",
+        help="Attach a debugging session to a running instance started with --debug",
     )
 
     parser.add_argument(
@@ -957,6 +964,15 @@ class KernelSource:
         else:
             self.virtme_param["balloon"] = ""
 
+    def _get_virtme_gdb(self, args):
+        if args.gdb:
+            def signal_handler(_signum, _frame):
+                pass  # No action needed for SIGINT in child (gdb will handle)
+            signal.signal(signal.SIGINT, signal_handler)
+            self.virtme_param["gdb"] = "--gdb"
+        else:
+            self.virtme_param["gdb"] = ""
+
     def _get_virtme_snaps(self, args):
         if args.snaps:
             self.virtme_param["snaps"] = "--snaps"
@@ -1026,6 +1042,7 @@ class KernelSource:
         self._get_virtme_memory(args)
         self._get_virtme_numa(args)
         self._get_virtme_balloon(args)
+        self._get_virtme_gdb(args)
         self._get_virtme_snaps(args)
         self._get_virtme_busybox(args)
         self._get_virtme_qemu(args)
@@ -1062,6 +1079,7 @@ class KernelSource:
             + f'{self.virtme_param["memory"]} '
             + f'{self.virtme_param["numa"]} '
             + f'{self.virtme_param["balloon"]} '
+            + f'{self.virtme_param["gdb"]} '
             + f'{self.virtme_param["snaps"]} '
             + f'{self.virtme_param["busybox"]} '
             + f'{self.virtme_param["qemu"]} '


### PR DESCRIPTION
Introduce a `--gdb` option in vng to automatically attach a gdb session to a running instance previously started with `--debug`.

The `--gdb` option implement some automation to figure out the location of vmlinux and provide and easy way to access kernel debugging.

TODO:
 - improve the automation to figure out also the sources of the distro kernel searching in some known locations
 - support multiple distro (right now vng is looking only for local vmlinux or Ubuntu kernel vmlinux)

This was discussed in #101.