### PR TITLE
init: Fall back to mounting without xino option

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -28,8 +28,9 @@ for tag in "${!virtme_rw_overlay@}"; do
     upperdir="/run/tmp/$tag/upper"
     workdir="/run/tmp/$tag/work"
     mkdir -p "$upperdir" "$workdir"
-    mnt_opts="xino=off,lowerdir=$dir,upperdir=$upperdir,workdir=$workdir"
-    mount -t overlay -o "${mnt_opts}" "${tag}" "${dir}" &
+    mnt_opts="lowerdir=$dir,upperdir=$upperdir,workdir=$workdir"
+    mount -t overlay -o xino=off,"${mnt_opts}" "${tag}" "${dir}" || \
+        mount -t overlay -o "${mnt_opts}" "${tag}" "${dir}" &
 done
 
 # Setup kernel modules


### PR DESCRIPTION
Older kernels don't support the 'xino' overlayfs mount option so we end up with no overlay mounts. Fall back to mounting without that option to work around that. It's not pretty as we end up with errors like:

[    0.380206] overlayfs: unrecognized mount option "xino=off" or missing value
[    0.383246] overlayfs: unrecognized mount option "xino=off" or missing value