### PR TITLE
setup.py: Check if argparse-manpage is present to vng.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,15 @@ if build_virtme_ng_init:
     package_files.append("bin/virtme-ng-init")
     packages.append("virtme.guest.bin")
 
+data_files = [
+    ("/etc", ["cfg/virtme-ng.conf"]),
+    ("/usr/share/bash-completion/completions", ["virtme-ng-prompt"]),
+    ("/usr/share/bash-completion/completions", ["vng-prompt"]),
+]
+
+if which('argparse-manpage'):
+    data_files.append(("/usr/share/man/man1", ["vng.1"]))
+
 setup(
     name="virtme-ng",
     version=VERSION,
@@ -171,12 +180,7 @@ setup(
     },
     packages=packages,
     package_data={"virtme.guest": package_files},
-    data_files=[
-        ("/etc", ["cfg/virtme-ng.conf"]),
-        ("/usr/share/bash-completion/completions", ["virtme-ng-prompt"]),
-        ("/usr/share/bash-completion/completions", ["vng-prompt"]),
-        ("/usr/share/man/man1", ["vng.1"]),
-    ],
+    data_files=data_files,
     scripts=[
         "bin/virtme-prep-kdir-mods",
     ],


### PR DESCRIPTION
Without this change, when trying to install virtme-ng using pip/pipx would return an error:

...
      copying virtme-ng-prompt -> build/bdist.linux-x86_64/wheel/usr/share/bash-completion/completions
      copying vng-prompt -> build/bdist.linux-x86_64/wheel/usr/share/bash-completion/completions
      creating build/bdist.linux-x86_64/wheel/usr/share/man
      creating build/bdist.linux-x86_64/wheel/usr/share/man/man1
      error: can't copy 'vng.1': doesn't exist or not a regular file
      [end of output]

The vng.1 file will only be generated if argparse-manpages is present, so also include the vng.1 file into data_files only if the package is present.