### PR TITLE
virtme-configkernel: 'O=' takes precedence over KBUILD_OUTPUT

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -336,6 +336,10 @@ def do_it():
 
     # Propagate additional Makefile variables
     for var in args.envs:
+        if var.startswith("O="):
+            # Setting "O=..." takes precedence over KBUILD_OUTPUT.
+            os.environ["KBUILD_OUTPUT"] = var[2:]
+
         archargs.append(shlex.quote(var))
 
     # Determine if an initial config is present


### PR DESCRIPTION
For the moment, it is required to set KBUILD_OUTPUT env var, and not just passing O=, because only KBUILD_OUTPUT env var is used to find the path to the .config file.

If O= is set in the env vars for make, then use it to override KBUILD_OUTPUT env var, as it is done on the kernel side.

Reported-by: @jimc
Closes: #127