### PR TITLE
version: generate verison string based on git information

### DIFF
--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -3,7 +3,39 @@
 
 """virtme-ng version"""
 
-VERSION = "1.25"
+from subprocess import check_output, DEVNULL, CalledProcessError
 
-if __name__ == '__main__':
+PKG_VERSION = "1.25"
+
+
+def get_version_string():
+    try:
+        # Get the version from git describe
+        version = (
+            check_output(
+                "git describe --always --long --dirty",
+                shell=True,
+                stderr=DEVNULL,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+
+        # Remove the 'v' prefix if present
+        if version.startswith("v"):
+            version = version[1:]
+
+        # Replace hyphens with plus sign for build metadata
+        version_pep440 = version.replace("-", "+", 1).replace("-", ".")
+
+        return version_pep440
+    except CalledProcessError:
+        # Default version if git describe fails (e.g., when building virtme-ng
+        # from a source package.
+        return PKG_VERSION
+
+
+VERSION = get_version_string()
+
+if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
If virtme-ng is installed from the git repository add git information to the version string.

If, for any reason, we fail to determine the git information (e.g., when building virtme-ng from a distro source package), fallback to the main packaging version, typically updated manually every time we cut a new release.

Suggested-by: Jim Cromie <jim.cromie@gmail.com>