### PR TITLE
version: run git describe from the path of the python file

### DIFF
--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -3,6 +3,7 @@
 
 """virtme-ng version"""
 
+import os
 from subprocess import check_output, DEVNULL, CalledProcessError
 
 PKG_VERSION = "1.25"
@@ -13,7 +14,7 @@ def get_version_string():
         # Get the version from git describe
         version = (
             check_output(
-                "git describe --always --long --dirty",
+                "cd %s && git describe --always --long --dirty" % os.path.dirname(__file__),
                 shell=True,
                 stderr=DEVNULL,
             )


### PR DESCRIPTION
When we append the git information to the version string we can't simply run git describe from any location, or we may end up getting the version of another git repository (like the kernel).

To prevent this, always run `git describe` from the path where version.py is located: installed vesions will return the plain version as before, while running `vng --version` directly from the git repo will return the version with the additional git information.

Fixes: 5cdb2f0 ("version: generate verison string based on git information")