### PR TITLE
version: make sure to get the git version from a virtme-ng git repo

### DIFF
--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -11,10 +11,16 @@ PKG_VERSION = "1.25"
 
 def get_version_string():
     try:
-        # Get the version from git describe
+        # Get the version from `git describe`.
+        #
+        # Make sure to get the proper git repository by using the directory
+        # that contains this file and also make sure that the parent is a
+        # virtme-ng repository.
+        #
+        # Otherwise fallback to the static version defined in PKG_VERSION.
         version = (
             check_output(
-                "cd %s && git describe --always --long --dirty" % os.path.dirname(__file__),
+                "cd %s && [ -e ../.git ] && git describe --always --long --dirty" % os.path.dirname(__file__),
                 shell=True,
                 stderr=DEVNULL,
             )


### PR DESCRIPTION
When we run git describe to append the git information to the version string, make sure that the version.py module is contained in a virtme-ng git repository, to avoid using information from any git repository in any parent directory.

Reported-by: Matthieu Baerts (NGI0) <matttbe@kernel.org>