### PR TITLE
Add cross-compile argument

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -32,6 +32,13 @@ def make_parser():
     )
 
     parser.add_argument(
+        "--cross-compile",
+        action="store",
+        metavar="CROSS_COMPILE_PREFIX",
+        help="Cross-compile compiler prefix",
+    )
+
+    parser.add_argument(
         "--custom",
         action="append",
         metavar="CUSTOM",
@@ -313,9 +320,13 @@ def do_it():
     linuxname = shlex.quote(arch.linuxname)
     archargs = [f"ARCH={linuxname}"]
 
-    if shutil.which(f"{arch.gccname}-linux-gnu-gcc") and arch.gccname != uname.machine:
-        gccname = shlex.quote(f"{arch.gccname}-linux-gnu-")
-        archargs.append(f"CROSS_COMPILE={gccname}")
+    cross_compile_prefix = f"{arch.gccname}-linux-gnu-"
+    if args.cross_compile != "":
+        cross_compile_prefix = args.cross_compile
+
+    if shutil.which(f"{cross_compile_prefix}-gcc") and arch.gccname != uname.machine:
+        gccname = shlex.quote(cross_compile_prefix)
+        archargs.append(f"CROSS_COMPILE={cross_compile_prefix}")
 
     maketarget: Optional[str]
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -205,6 +205,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="Guest architecture",
     )
     g.add_argument(
+        "--cross-compile",
+        action="store",
+        metavar="CROSS_COMPILE_PREFIX",
+        help="Cross-compile compiler prefix",
+    )
+    g.add_argument(
         "--busybox",
         action="store",
         metavar="PATH_TO_BUSYBOX",

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -443,6 +443,12 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     parser.add_argument(
+        "--cross-compile",
+        action="store",
+        help="Set cross-compile prefix"
+    )
+
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Force reset git repository to target branch or commit "
@@ -733,6 +739,9 @@ class KernelSource:
                 arg_fail(f"unsupported architecture: {arch}")
             target = ARCH_MAPPING[arch]["kernel_target"]
             cross_compile = ARCH_MAPPING[arch]["cross_compile"]
+            if args.cross_compile != "":
+                cross_compile=args.cross_compile
+
             cross_arch = ARCH_MAPPING[arch]["linux_name"]
         else:
             target = "bzImage"


### PR DESCRIPTION
When cross-compiling on SUSE distributions vng fails to find gcc, since it's named '<arch>-suse-linux-gcc', instead of the hardcoded '<arch>-linux-gnu-gcc'.

This commit provides a '--cross-compile' argument that will override the hardcoded prefix if used, otherwise it should do nothing.