### PR TITLE
version: try to get version from pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ from subprocess import check_call, CalledProcessError
 from setuptools import setup, Command
 from setuptools.command.build_py import build_py
 from setuptools.command.egg_info import egg_info
-from virtme_ng.version import VERSION
+from virtme_ng.version import get_version_string
+
+os.environ["__VNG_LOCAL"] = "1"
+VERSION = get_version_string()
 
 # Source .config if it exists (where we can potentially defined config/build
 # options)
@@ -52,6 +55,7 @@ class LintCommand(Command):
             for cmd in ("flake8", "pylint"):
                 command = [cmd]
                 for pattern in (
+                    "vng",
                     "*.py",
                     "virtme/*.py",
                     "virtme/*/*.py",

--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -5,12 +5,23 @@
 
 import os
 from subprocess import check_output, DEVNULL, CalledProcessError
+import pkg_resources
 
 PKG_VERSION = "1.25"
 
 
+def get_package_version():
+    try:
+        return pkg_resources.get_distribution("virtme-ng").version
+    except pkg_resources.DistributionNotFound:
+        return PKG_VERSION
+
+
 def get_version_string():
     try:
+        if not os.environ.get("__VNG_LOCAL"):
+            return get_package_version()
+
         # Get the version from `git describe`.
         #
         # Make sure to get the proper git repository by using the directory
@@ -37,9 +48,9 @@ def get_version_string():
 
         return version_pep440
     except CalledProcessError:
-        # Default version if git describe fails (e.g., when building virtme-ng
-        # from a source package.
-        return PKG_VERSION
+        # If git describe fails to determine a version, try to use the version
+        # from pip, or ultimately simply return the hard-coded package version.
+        return get_package_version()
 
 
 VERSION = get_version_string()

--- a/vng
+++ b/vng
@@ -7,7 +7,9 @@
 
 import os
 import sys
-from virtme_ng import run
+os.environ["__VNG_LOCAL"] = "1"
+from virtme_ng import run  # noqa: E402
+
 
 # Update PATH to make sure that virtme-ng can be executed directly from the
 # source directory, without necessarily installing virtme-ng in the system.
@@ -17,5 +19,6 @@ def update_path():
     new_path = f'{script_dir}:{current_path}'
     os.environ['PATH'] = new_path
 
+
 update_path()
-exit(run.main())
+sys.exit(run.main())


### PR DESCRIPTION
If we can't determine any version info from `git describe` try to get the version from pip, otherwise fallback to the hard-coded package version.

Also force to use the git version string both when we are installing (setup.py) the package or when we are directly running vng from the source repo.