### PR TITLE
version: fallback to `PKG_VERSION` if `git describe` failed

### DIFF
--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -48,9 +48,11 @@ def get_version_string():
 
         return version_pep440
     except CalledProcessError:
-        # If git describe fails to determine a version, try to use the version
-        # from pip, or ultimately simply return the hard-coded package version.
-        return get_package_version()
+        # If git describe fails to determine a version (e.g. building from the
+        # source using a tarball), the version from pip cannot be picked because
+        # it might be different than the local one being used here. Fall back to
+        # the hard-coded package version then.
+        return PKG_VERSION
 
 
 VERSION = get_version_string()

--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -18,10 +18,10 @@ def get_package_version():
 
 
 def get_version_string():
-    try:
-        if not os.environ.get("__VNG_LOCAL"):
-            return get_package_version()
+    if not os.environ.get("__VNG_LOCAL"):
+        return get_package_version()
 
+    try:
         # Get the version from `git describe`.
         #
         # Make sure to get the proper git repository by using the directory


### PR DESCRIPTION
Now that 'git describe' is only used for local version, it means that in case of issue with the git command, the version from pip cannot be picked as an alternative, because it might be different from the local one being used here. A fallback to the hard-coded package version seems to be the only alternative if 'git describe' cannot be used.

This cover the case of someone using the source code from a tarball, without git support, but potentially having a different version already installed with pip.

Linked to the discussions on #138 