### PR TITLE
More version - was mk install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,7 @@ install: install_from_source
 install_from_source:
 	@echo "Version: $(GIT_DESCRIBE)"
 	BUILD_VIRTME_NG_INIT=1 pip3 install --verbose -r requirements.txt $(INSTALL_ARGS) .
+
+install_only_top:
+	@echo "Version: $(GIT_DESCRIBE)"
+	BUILD_VIRTME_NG_INIT=0 pip3 install --verbose -r requirements.txt $(INSTALL_ARGS) .

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+INSTALL_ARGS :=	# todo: add --break-system-packages if ubuntu
+
 .PHONY: init
 init:
 	cd virtme_ng_init && cargo install --path . --root ../virtme/guest
+
+# see README.md '* Install from source'
+install: install_from_source
+install_from_source:
+	BUILD_VIRTME_NG_INIT=1 pip3 install --verbose -r requirements.txt $(INSTALL_ARGS) .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 INSTALL_ARGS :=	# todo: add --break-system-packages if ubuntu
 
+# Get git version information for make install
+GIT_DESCRIBE := $(shell git describe --always --long --dirty)
+
 .PHONY: init
 init:
 	cd virtme_ng_init && cargo install --path . --root ../virtme/guest
@@ -7,4 +10,5 @@ init:
 # see README.md '* Install from source'
 install: install_from_source
 install_from_source:
+	@echo "Version: $(GIT_DESCRIBE)"
 	BUILD_VIRTME_NG_INIT=1 pip3 install --verbose -r requirements.txt $(INSTALL_ARGS) .


### PR DESCRIPTION
revision of mk-install sent previously

76d123d (HEAD -> more-version, ghlinux/more-version) Makefile - add install-top-only target
0148f15 run git describe in Makefile
840756b add Makefile install target

adds make install target, 2 different ways (INIT=0/1)
and sets make var from git describe, in the srcdir.
It doesnt handle tarball distros, 
but the git describe, if it works, is from a known location.

ISTM that pip install could capture it to the binary ??