### PR TITLE
virtme: pass "debug" to the boot options when running in verbose mode

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1063,7 +1063,7 @@ def do_it() -> int:
             qemuargs.extend(["-chardev", "file,path=/proc/self/fd/2,id=dmesg"])
             qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
             qemuargs.extend(["-device", "virtconsole,chardev=dmesg"])
-            kernelargs.extend(["console=hvc0"])
+            kernelargs.extend(["console=ttyS0", "debug"])
 
             # Unfortunately we can't use hvc0 to redirect early console
             # messages to stderr, so just send them to the main console, in


### PR DESCRIPTION
Some distro / kernels require the "debug" boot option to properly show the kernel messages to the console.

Add this parameter to correctly show the kernel log when "-v" is used.

This allows to properly show the kernel log in Arch Linux, CachyOS (and probably most of the Arch-derivative distro).