### PR TITLE
virtme: switch back to hypervisor console

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1063,7 +1063,7 @@ def do_it() -> int:
             qemuargs.extend(["-chardev", "file,path=/proc/self/fd/2,id=dmesg"])
             qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
             qemuargs.extend(["-device", "virtconsole,chardev=dmesg"])
-            kernelargs.extend(["console=ttyS0"])
+            kernelargs.extend(["console=hvc0"])
 
             # Unfortunately we can't use hvc0 to redirect early console
             # messages to stderr, so just send them to the main console, in


### PR DESCRIPTION
It looks like it was accidentally modified [1].

The hypervisor console is supposed to be better, except to debug early console stuff. But that's OK, another serial is used for that: ttyS0 or ttyAMA0, depending on the arch.

Fixes: 4bf382a ("virtme: pass "debug" to the boot options when running in verbose mode")
Link: https://github.com/arighi/virtme-ng/pull/144 [1]