### PR TITLE
Outdir

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -103,7 +103,7 @@ def arg_fail(message):
 
 
 _GENERIC_CONFIG = [
-    "# Generic",
+    "##: Generic",
     "CONFIG_UEVENT_HELPER=n",  # Obsolete and slow
     "CONFIG_VIRTIO=y",
     "CONFIG_VIRTIO_PCI=y",
@@ -131,25 +131,25 @@ _GENERIC_CONFIG = [
     "CONFIG_EARLY_PRINTK=y",
     "CONFIG_INOTIFY_USER=y",
     "",
-    "# virtio-scsi support",
+    "##: virtio-scsi support",
     "CONFIG_BLOCK=y",
     "CONFIG_SCSI_LOWLEVEL=y",
     "CONFIG_SCSI=y",
     "CONFIG_SCSI_VIRTIO=y",
     "CONFIG_BLK_DEV_SD=y",
     "",
-    "# virt-serial support",
+    "##: virt-serial support",
     "CONFIG_VIRTIO_CONSOLE=y",
     "",
-    "# watchdog (useful for test scripts)",
+    "##: watchdog (useful for test scripts)",
     "CONFIG_WATCHDOG=y",
     "CONFIG_WATCHDOG_CORE=y",
     "CONFIG_I6300ESB_WDT=y",
-    "# Make sure debuginfo are available",
+    "##: Make sure debuginfo are available",
     "CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y",
-    "# Enable overlayfs",
+    "##: Enable overlayfs",
     "CONFIG_OVERLAY_FS=y",
-    "# virtio-fs support",
+    "##: virtio-fs support",
     "CONFIG_DAX=y",
     "CONFIG_DAX_DRIVER=y",
     "CONFIG_FS_DAX=y",
@@ -161,9 +161,9 @@ _GENERIC_CONFIG = [
 ]
 
 _GENERIC_CONFIG_OPTIONAL = [
-    "# initramfs support",
+    "##: initramfs support",
     "CONFIG_BLK_DEV_INITRD=y",
-    "# BPF stuff & useful debugging features",
+    "##: BPF stuff & useful debugging features",
     "CONFIG_BPF=y",
     "CONFIG_BPF_SYSCALL=y",
     "CONFIG_BPF_JIT=y",
@@ -180,16 +180,16 @@ _GENERIC_CONFIG_OPTIONAL = [
     "CONFIG_UPROBES=y",
     "CONFIG_UPROBE_EVENTS=y",
     "CONFIG_DEBUG_FS=y",
-    "# Required to generate memory dumps for drgn",
+    "##: Required to generate memory dumps for drgn",
     "CONFIG_FW_CFG_SYSFS=y",
     "CONFIG_FW_CFG_SYSFS_CMDLINE=y",
-    "# Graphics support",
+    "##: Graphics support",
     "CONFIG_DRM=y",
     "CONFIG_DRM_VIRTIO_GPU=y",
     "CONFIG_DRM_VIRTIO_GPU_KMS=y",
     "CONFIG_DRM_BOCHS=y",
     "CONFIG_VIRTIO_IOMMU=y",
-    "# Sound support",
+    "##: Sound support",
     "CONFIG_SOUND=y",
     "CONFIG_SND=y",
     "CONFIG_SND_SEQUENCER=y",
@@ -296,7 +296,7 @@ def do_it():
 
     mod_conf = []
     if args.configitem:
-        mod_conf += ["# final config-item mods"]
+        mod_conf += ["##: final config-item mods"]
         for conf_item in args.configitem:
             if not conf_item.startswith("CONFIG_"):
                 conf_item = "CONFIG_" + conf_item
@@ -307,7 +307,7 @@ def do_it():
 
     conf = (
         _GENERIC_CONFIG_OPTIONAL
-        + ["# Arch-specific options"]
+        + ["##: Arch-specific options"]
         + arch.config_base()
         + custom_conf
         + mod_conf

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -355,11 +355,13 @@ def do_it():
 
     # Determine if an initial config is present
     config = ".config"
+    makef = "Makefile"
 
     # Check if KBUILD_OUTPUT is defined and if it's a directory
     config_dir = os.environ.get("KBUILD_OUTPUT", "")
     if config_dir and os.path.isdir(config_dir):
         config = os.path.join(config_dir, config)
+        makef = os.path.join(config_dir, makef)
 
     if os.path.exists(config):
         if args.no_update:
@@ -371,12 +373,23 @@ def do_it():
             return 1
 
     if maketarget is not None:
+        make_args = []
+        if not os.path.exists(makef):
+            if args.verbose:
+                sys.stderr.write(f"missing {makef}, adding -f $src/Makefile\n")
+            if os.path.exists("Makefile"):
+                # assuming we're in linux srcdir
+                make_args = ["-f", str(os.path.abspath("Makefile"))]
+                if args.verbose:
+                    sys.stderr.write(f"adding make_args: {make_args}\n")
         try:
-            subprocess.check_call(["make"] + archargs + [maketarget])
+            subprocess.check_call(["make"] + make_args + archargs + [maketarget])
         except Exception as exc:
             raise SilentError() from exc
 
     # Append virtme configs
+    if args.verbose:
+        sys.stderr.write(f"appending to config: {config}\n")
     with open(config, "ab") as conffile:
         conffile.write("\n".join(conf).encode("utf-8"))
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -207,6 +207,7 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
 
     parser.add_argument(
         "--config",
+        "--custom",
         "-f",
         action="append",
         help="Use one (or more) specific kernel .config snippet "

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -611,6 +611,8 @@ class KernelSource:
         """Perform a make config operation on a kernel source directory."""
         arch = args.arch
         cmd = "virtme-configkernel --defconfig"
+        if args.verbose:
+            cmd += " --verbose"
         if not args.force and not args.kconfig:
             cmd += " --no-update"
         if arch is not None:
@@ -630,6 +632,8 @@ class KernelSource:
         # Propagate additional Makefile variables
         for var in args.envs:
             cmd += f" {var} "
+        if args.verbose:
+            print(f"cmd: {cmd}")
         check_call_cmd(
             self._format_cmd(cmd), quiet=not args.verbose, dry_run=args.dry_run
         )

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -873,7 +873,11 @@ class KernelSource:
             else:
                 self.virtme_param["kdir"] = "--kimg " + args.run
         else:
-            self.virtme_param["kdir"] = "--kdir ./"
+            for var in args.envs:
+                if var.startswith("O="):
+                    self.virtme_param["kdir"] = "--kdir ./" + var[2:]
+            if self.virtme_param.get("kdir") is None:
+                self.virtme_param["kdir"] = "--kdir ./"
 
     def _get_virtme_mods(self, args):
         if args.skip_modules:


### PR DESCRIPTION
hi Andrea,

this is a rework of the previous patchset, some of which you committed already,
then I closed the PR.   Things are basically unchanged, with more confident commit-msgs.

Its all about O=outdir, 1st in config-kernel, then in vng, which uses it.

NB:  O=outdir is implicitly path relative, as it translates to --kdir ./  qemu arg.
This may relate at least peripherally to PR #141

