### PR TITLE
Two fixes for small issues encountered with "--build-host"

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -593,7 +593,7 @@ class KernelSource:
 
     def checkout(self, args):
         """Perform a git checkout operation on a local kernel git repository."""
-        if not os.path.isdir(".git"):
+        if not os.path.exists(".git"):
             arg_fail("error: must run from a kernel git repository", show_usage=False)
         target = args.commit or "HEAD"
         if args.build_host is not None or target != "HEAD":
@@ -728,7 +728,7 @@ class KernelSource:
 
     def make(self, args):
         """Perform a make operation on a kernel source directory."""
-        if not os.path.isdir(".git") and args.build_host is not None:
+        if not os.path.exists(".git") and args.build_host is not None:
             arg_fail(
                 "error: --build-host can be used only on a kernel git repository",
                 show_usage=False,
@@ -1156,7 +1156,7 @@ class KernelSource:
 
     def clean(self, args):
         """Clean a local or remote git repository."""
-        if not os.path.isdir(".git"):
+        if not os.path.exists(".git"):
             arg_fail("error: must run from a kernel git repository", show_usage=False)
         if args.build_host is None:
             cmd = self._format_cmd("git clean -xdf")

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -658,7 +658,7 @@ class KernelSource:
                 "--force",
                 "--porcelain",
                 f"{args.build_host}:~/.virtme",
-                "HEAD:__virtme__",
+                "HEAD:refs/heads/__virtme__",
             ],
             quiet=not args.verbose,
             dry_run=args.dry_run,


### PR DESCRIPTION
I encountered two issues while using `vng --build --build-host` and thought I'd fix them up. One is due to my use of [git worktrees](https://git-scm.com/docs/git-worktree/en) (so the `.git` is not a directory), and the other was an issue that came up due to the first-time `git push` to my build host.

Thanks for this project, it's really convenient :)