### PR TITLE
virtme-configkernel: disable nvram support

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -277,6 +277,7 @@ _GENERIC_CONFIG_OPTIONAL = [
     "# CONFIG_MSDOS_FS is not set",
     "# CONFIG_AUTOFS4_FS is not set",
     "# CONFIG_AUTOFS_FS is not set",
+    "# CONFIG_NVRAM is not set",
 ]
 
 


### PR DESCRIPTION
We don't need to enable nvram support by default in the guest and having this disabled can save a few millisec during boot.