### PR TITLE
vng: allow to use -rc kernels from Ubuntu mainline builds

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -865,7 +865,7 @@ class KernelSource:
             # If an upstream version is specified (using an upstream tag) fetch
             # and run the corresponding kernel from the Ubuntu mainline
             # repository.
-            if re.match(r'^v\d+(\.\d+)*$', args.run):
+            if re.match(r'^v\d+(\.\d+)*(-rc\d+)?$', args.run):
                 if args.arch is None:
                     arch = 'amd64'
                 else:


### PR DESCRIPTION
Allow to download -rc precompiled mainline kernels from the Ubuntu mainline kernel repository (https://kernel.ubuntu.com/mainline).

Before:
 $ vng -r v6.11-rc7 -- uname -r
 v6.11-rc7 does not exist

After:
 $ vng -r v6.11-rc7 -- uname -r
 6.11.0-061100rc7-generic