### PR TITLE
enable virtme-ng to install via pipx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 argcomplete
 argparse-manpage
 requests
+setuptools
+

--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -47,7 +47,7 @@ def get_version_string():
             version = version[1:]
 
         # Replace hyphens with plus sign for build metadata
-        version_pep440 = version.replace("-", "+", 1).replace("-", ".")
+        version_pep440 = '0.0+dev'+version.replace("-", "+").replace("+", ".")
 
         return version_pep440
     except CalledProcessError:


### PR DESCRIPTION
This pr makes two changes to enable installing/running vng via pipx.
pipx is the thing pip install recommends to use to install packages instead of `--break-system-packages`.

(1) it adds setup tools to requirements to fix the following issue:
```
patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 
❯ pipx install .
  installed package virtme-ng 1.29+2.gdb83b56, installed using Python 3.12.3
  These apps are now globally available
    - virtme-configkernel
    - virtme-mkinitramfs
    - virtme-ng
    - virtme-prep-kdir-mods
    - virtme-run
    - vng
done! ✨ 🌟 ✨

patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 took 3s 
❯ virtme-ng
Traceback (most recent call last):
  File "/home/patso/.local/bin/virtme-ng", line 5, in <module>
    from virtme_ng.run import main
  File "/home/patso/.local/share/pipx/venvs/virtme-ng/lib/python3.12/site-packages/virtme_ng/run.py", line 35, in <module>
    from virtme_ng.version import VERSION
  File "/home/patso/.local/share/pipx/venvs/virtme-ng/lib/python3.12/site-packages/virtme_ng/version.py", line 8, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

(2) It ensures that the version is pep440 compliant when install is ran with `BUILD_VIRTME_NG_INIT` (not sure why that triggers this but didn't look a ton):
```
patso in 🌐 ubuntu in virtme-ng on  HEAD (7fe8f67) via 🐍 v3.12.3 
❯ BUILD_VIRTME_NG_INIT=1 pipx install .
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [34 lines of output]
      Traceback (most recent call last):
        File "/home/patso/.local/share/pipx/shared/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/patso/.local/share/pipx/shared/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/patso/.local/share/pipx/shared/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 503, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 164, in <module>
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 146, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 294, in __init__
          self.metadata.version = self._normalize_version(self.metadata.version)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 330, in _normalize_version
          normalized = str(Version(version))
                           ^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-mmipidcy/overlay/lib/python3.12/site-packages/setuptools/_vendor/packaging/version.py", line 202, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      packaging.version.InvalidVersion: Invalid version: '7fe8f67'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Cannot determine package name from spec '/home/patso/virtme-ng'. Check package spec for errors.
[ble: exit 1]
```

After this pr, install/run looks like the following in a couple of test cases:
```
patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 
❯ pipx install .
  installed package virtme-ng 0.0+dev27b7bc8, installed using Python 3.12.3
  These apps are now globally available
    - virtme-configkernel
    - virtme-mkinitramfs
    - virtme-ng
    - virtme-prep-kdir-mods
    - virtme-run
    - vng
done! ✨ 🌟 ✨

patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 took 4s 
❯ vng  
kernel file ./arch/x86/boot/bzImage does not exist, try --build to build the kernel
[ble: exit 1]

patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 
❯ pipx uninstall virtme-ng
uninstalled virtme-ng! ✨ 🌟 ✨

patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 
❯ BUILD_VIRTME_NG_INIT=1 pipx install .
  installed package virtme-ng 0.0+dev27b7bc8, installed using Python 3.12.3
  These apps are now globally available
    - virtme-configkernel
    - virtme-mkinitramfs
    - virtme-ng
    - virtme-prep-kdir-mods
    - virtme-run
    - vng
done! ✨ 🌟 ✨

patso in 🌐 ubuntu in virtme-ng on  main via 🐍 v3.12.3 took 4s 
❯ vng
kernel file ./arch/x86/boot/bzImage does not exist, try --build to build the kernel
[ble: exit 1]

... 

patso in 🌐 ubuntu in sched_ext_linux on  master via 🐍 v3.12.3 took 25s 
❯ vng
          _      _
   __   _(_)_ __| |_ _ __ ___   ___       _ __   __ _
   \ \ / / |  __| __|  _   _ \ / _ \_____|  _ \ / _  |
    \ V /| | |  | |_| | | | | |  __/_____| | | | (_| |
     \_/ |_|_|   \__|_| |_| |_|\___|     |_| |_|\__  |
                                                |___/
   kernel version: 6.11.0-rc1-virtme x86_64
   (CTRL+d to exit)

[WARN] - (starship::utils): Executing command "/usr/bin/git" timed out.
[WARN] - (starship::utils): You can set command_timeout in your config to a higher value to allow longer-running commands to keep executing.

virtme-ng in sched_ext_linux on  master via 🐍 v3.12.3 
❯ 

```

