### PR TITLE
Avoid prepending the version with `0.0+dev` all the time

### DIFF
--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -34,7 +34,7 @@ def get_version_string():
         # Otherwise fallback to the static version defined in PKG_VERSION.
         version = (
             check_output(
-                "cd %s && [ -e ../.git ] && git describe --always --long --dirty" % os.path.dirname(__file__),
+                "cd %s && [ -e ../.git ] && git describe --long --dirty" % os.path.dirname(__file__),
                 shell=True,
                 stderr=DEVNULL,
             )

--- a/virtme_ng/version.py
+++ b/virtme_ng/version.py
@@ -47,7 +47,7 @@ def get_version_string():
             version = version[1:]
 
         # Replace hyphens with plus sign for build metadata
-        version_pep440 = '0.0+dev'+version.replace("-", "+").replace("+", ".")
+        version_pep440 = version.replace("-", "+", 1).replace("-", ".")
 
         return version_pep440
     except CalledProcessError:


### PR DESCRIPTION
A recent change has modified how the version was printed. I think the issue was due to the git repo not having any tags, causing an unexpected string, not looking like a version.

Instead, a fallback to the package version is now done when there are no git tags.