### PR TITLE
Enable ppc64le to work with "vng -r" argument

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -71,6 +71,9 @@ class Arch:
     def kimg_path(self) -> str:
         return "arch/%s/boot/bzImage" % self.linuxname
 
+    def img_name(self) -> str:
+        return "vmlinuz"
+
     @staticmethod
     def dtb_path() -> Optional[str]:
         return None
@@ -310,6 +313,9 @@ class Arch_ppc(Arch):
 
     def kimg_path(self):
         # Apparently SLOF (QEMU's bundled firmware?) can't boot a zImage.
+        return "vmlinux"
+
+    def img_name(self) -> str:
         return "vmlinux"
 
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -380,7 +380,7 @@ def get_kernel_version(path):
             ["file", path], capture_output=True, text=True, check=False
         )
         for item in result.stdout.split(", "):
-            match = re.search(r"^[vV]ersion (\S+)", item)
+            match = re.search(r"^[vV]ersion (\S{3,})", item)
             if match:
                 kernel_version = match.group(1)
                 return kernel_version
@@ -393,7 +393,7 @@ def get_kernel_version(path):
     result = subprocess.run(
         ["strings", path], capture_output=True, text=True, check=False
     )
-    match = re.search(r"Linux version (\S+)", result.stdout)
+    match = re.search(r"Linux version (\S{3,})", result.stdout)
     if match:
         kernel_version = match.group(1)
         return kernel_version

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -428,11 +428,13 @@ def find_kernel_and_mods(arch, args) -> Kernel:
                 args.kimg = None
 
     if args.kimg is not None:
+        img_name = arch.img_name()
+
         # Try to resolve kimg as a kernel version first, then check if a file
         # is provided.
-        kimg = "/usr/lib/modules/%s/vmlinuz" % args.kimg
+        kimg = "/usr/lib/modules/%s/%s" % (args.kimg, img_name)
         if not os.path.exists(kimg):
-            kimg = "/boot/vmlinuz-%s" % args.kimg
+            kimg = "/boot/%s-%s" % (img_name, args.kimg)
             if not os.path.exists(kimg):
                 kimg = args.kimg
                 if not os.path.exists(kimg):


### PR DESCRIPTION
Currently is also fails on s390x, but because we fail to detect the kernel version. But this work will also to bring s390x support in the future.