### PR TITLE
S390x enablement

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -408,6 +408,9 @@ class Arch_s390x(Arch):
         return ["-device", "sclpconsole,chardev=console"]
 
 
+    def img_name(self) -> str:
+        return "image"
+
 ARCHES = {
     arch.virtmename: arch
     for arch in [


### PR DESCRIPTION
These two commits enabled us to run ./vng -r on our s390x SLE machines. I'm not sure if there are s390x experts around to double check the "image" naming of the kernel installed on s390x machines, but this is true for SLE.