### PR TITLE
NVIDIA gpu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,26 @@ Examples
    See also: `.github/workflows/run.yml` as a practical example on how to use
    virtme-ng inside docker.
 
+ - Run virtme-ng with gpu passthrough:
+```
+   # Confirm host kernel has VFIO and IOMMU support
+   # Check if NVIDIA module is installed on the host
+   $ modinfo nvidia
+   # If the nvidia module is installed, blacklist the nvidia modules
+   $ sudo bash -c 'echo -e "blacklist nvidia\nblacklist nvidia-drm\nblacklist nvidia-modeset\nblacklist nvidia-peermem\nblacklist nvidia-uvm" > /etc/modprobe.d/blacklist-nvidia.conf'
+   # Host will need to be rebooted for blacklist to take effect.
+   # Get GPU device ID
+   $ lspci -nn | grep NVIDIA
+     0000:01:00.0 VGA compatible controller [0300]: NVIDIA Corporation AD104GLM [RTX 3500 Ada Generation Laptop GPU] [10de:27bb] (rev a1)
+     0000:01:00.1 Audio device [0403]: NVIDIA Corporation Device [10de:22bc] (rev a1))
+   # Configure VFIO for device passthrough
+   $ sudo bash -c 'options vfio-pci ids=10de:27bb,10de:22bc' > /etc/modprobe.d/vfio.conf
+   # Load VFIO module
+   $ sudo modprobe vfio-pci
+   # Pass PCI address to virtme-ng
+   $ sudo vng --nvgpu "01:00.0" -r linux
+```
+
 Implementation details
 ======================
 

--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -51,6 +51,10 @@ class Arch:
         return ["-vga", "none", "-display", "none"]
 
     @staticmethod
+    def qemu_nodisplay_nvgpu_args() -> List[str]:
+        return ["-display", "none"]
+
+    @staticmethod
     def qemu_display_args() -> List[str]:
         return ["-device", "virtio-gpu-pci"]
 
@@ -106,7 +110,7 @@ class Arch_x86(Arch):
         if is_native and use_kvm:
             # If we're likely to use KVM, request a full-featured CPU.
             # (NB: if KVM fails, this will cause problems.  We should probe.)
-            ret.extend(["-cpu", "host"])  # We can't migrate regardless.
+            ret.extend(["-cpu", "host,host-phys-bits-limit=0x28"])  # We can't migrate regardless.
         else:
             ret.extend(["-machine", "q35"])
 

--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -23,9 +23,10 @@ class Arch:
         return False
 
     @staticmethod
-    def qemuargs(is_native, use_kvm) -> List[str]:
+    def qemuargs(is_native, use_kvm, use_gpu) -> List[str]:
         _ = is_native
         _ = use_kvm
+        _ = use_gpu
         return []
 
     @staticmethod
@@ -85,8 +86,8 @@ class Arch:
 
 class Arch_unknown(Arch):
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        return Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        return Arch.qemuargs(is_native, use_kvm, use_gpu)
 
 
 class Arch_x86(Arch):
@@ -101,8 +102,8 @@ class Arch_x86(Arch):
         return True
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
 
         # Add a watchdog.  This is useful for testing.
         ret.extend(["-device", "i6300esb,id=watchdog0"])
@@ -110,7 +111,10 @@ class Arch_x86(Arch):
         if is_native and use_kvm:
             # If we're likely to use KVM, request a full-featured CPU.
             # (NB: if KVM fails, this will cause problems.  We should probe.)
-            ret.extend(["-cpu", "host,host-phys-bits-limit=0x28"])  # We can't migrate regardless.
+            cpu_str = "host"
+            if use_gpu:
+                cpu_str += ",host-phys-bits-limit=0x28"
+            ret.extend(["-cpu", cpu_str])
         else:
             ret.extend(["-machine", "q35"])
 
@@ -186,8 +190,8 @@ class Arch_microvm(Arch_x86):
         ]
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
 
         # Use microvm architecture for faster boot
         ret.extend(["-M", "microvm,accel=kvm,pcie=on,rtc=on"])
@@ -207,8 +211,8 @@ class Arch_arm(Arch):
         self.defconfig_target = "vexpress_defconfig"
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
 
         # Emulate a vexpress-a15.
         ret.extend(["-M", "vexpress-a15"])
@@ -261,8 +265,8 @@ class Arch_aarch64(Arch):
         return True
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
 
         if is_native:
             ret.extend(["-M", "virt,gic-version=host"])
@@ -303,8 +307,8 @@ class Arch_ppc(Arch):
         self.gccname = "powerpc64le"
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
         ret.extend(["-M", "pseries"])
 
         return ret
@@ -341,8 +345,8 @@ class Arch_riscv64(Arch):
         return True
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
         ret.extend(["-machine", "virt"])
         ret.extend(["-bios", "default"])
 
@@ -366,8 +370,8 @@ class Arch_sparc64(Arch):
         self.gccname = "sparc64"
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        return Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        return Arch.qemuargs(is_native, use_kvm, use_gpu)
 
     def kimg_path(self):
         return "arch/sparc/boot/image"
@@ -391,8 +395,8 @@ class Arch_s390x(Arch):
         return "virtio-%s-ccw" % virtiotype
 
     @staticmethod
-    def qemuargs(is_native, use_kvm):
-        ret = Arch.qemuargs(is_native, use_kvm)
+    def qemuargs(is_native, use_kvm, use_gpu):
+        ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
 
         # Ask for the latest version of s390-ccw
         ret.extend(["-M", "s390-ccw-virtio"])

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1054,7 +1054,7 @@ def do_it() -> int:
         qemuargs.extend(["-machine", "accel=kvm:tcg"])
 
     # Add architecture-specific options
-    qemuargs.extend(arch.qemuargs(is_native, kvm_ok))
+    qemuargs.extend(arch.qemuargs(is_native, kvm_ok, args.nvgpu is not None))
 
     # Set up / override baseline devices
     qemuargs.extend(["-parallel", "none"])

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -465,6 +465,13 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         nargs="*",
         help="Additional Makefile variables",
     )
+
+    parser.add_argument(
+        "--nvgpu",
+        action="store",
+        metavar="[GPU PCI Address]",
+        help="Add a passthrough NVIDIA GPU",
+    )
     return parser
 
 
@@ -1041,6 +1048,12 @@ class KernelSource:
         else:
             self.virtme_param["qemu_opts"] = ""
 
+    def _get_virtme_nvgpu(self, args):
+        if args.nvgpu is not None:
+            self.virtme_param["nvgpu"] = f"--nvgpu 'vfio-pci,host={args.nvgpu}'"
+        else:
+            self.virtme_param["nvgpu"] = ""
+
     def run(self, args):
         """Execute a kernel inside virtme-ng."""
         self._get_virtme_name(args)
@@ -1076,6 +1089,7 @@ class KernelSource:
         self._get_virtme_busybox(args)
         self._get_virtme_qemu(args)
         self._get_virtme_qemu_opts(args)
+        self._get_virtme_nvgpu(args)
 
         # Start VM using virtme-run
         cmd = (
@@ -1113,6 +1127,7 @@ class KernelSource:
             + f'{self.virtme_param["busybox"]} '
             + f'{self.virtme_param["qemu"]} '
             + f'{self.virtme_param["qemu_opts"]} '
+            + f'{self.virtme_param["nvgpu"]} '
         )
         check_call(cmd, shell=True)
 


### PR DESCRIPTION
This PR enables gpu passthrough with virtme-ng.  It adds a new paramemeter "--nvgpu' which is used to provide the PCI address of the gpu.  There are included instructions in the README for enabling VFIO passthrough support.