### PR TITLE
virtme-ng: fix incorrect cross-compile override

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -752,7 +752,7 @@ class KernelSource:
                 arg_fail(f"unsupported architecture: {arch}")
             target = ARCH_MAPPING[arch]["kernel_target"]
             cross_compile = ARCH_MAPPING[arch]["cross_compile"]
-            if args.cross_compile != "":
+            if args.cross_compile:
                 cross_compile = args.cross_compile
 
             cross_arch = ARCH_MAPPING[arch]["linux_name"]


### PR DESCRIPTION
Properly check if the --cross-compile option has been specified, so that we can correctly use the built-in cross-compile prefixes.

This fixes the cross-architecture builds without using the --cross-compile option.

Fixes: e12dfb2 ("Add cross-compile argument")