### PR TITLE
Add hint when trying to create root filesystem outside a Debian host

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -542,11 +542,15 @@ def create_root(destdir, arch, release):
     # Use Ubuntu's cloud images to create a rootfs, these images are fairly
     # small and they provide a nice environment to test kernels.
     if release is None:
-        release = (
-            check_output("lsb_release -s -c", shell=True)
-            .decode(sys.stdout.encoding)
-            .rstrip()
-        )
+        try:
+            release = (
+                check_output("lsb_release -s -c", shell=True)
+                .decode(sys.stdout.encoding)
+                .rstrip()
+            )
+        except CalledProcessError as e:
+            print("Try specifying an Ubuntu release with --root-release")
+            raise e
     url = (
         "https://cloud-images.ubuntu.com/"
         + f"{release}/current/{release}-server-cloudimg-{arch}-root.tar.xz"


### PR DESCRIPTION
The user can specify a directory that does not exist with --root and the tool will create one for him. However, it depends on `lsb_release` which is not available in non-Debian hosts. Therefore, add a hint so the user knows what to do.