### PR TITLE
virtme: fix regex expecting a group

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -404,7 +404,7 @@ def get_kernel_version(img_name, path):
     # The version detection fails s390x using file or strings tools, so check
     # if the file itself contins the version number.
     if img_name:
-        match = re.search(fr"{img_name}-\S{{3,}}", path)
+        match = re.search(fr"{img_name}-(\S{{3,}})", path)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
Regex was changes when it was merged in a single format string, and the parenthesis describing group 1 were lost. Add them back to make sure it matches what we want.

This fixes booting a compressed pre-downloaded kernel on arm64.

Fixes: 3944645 ("virtme: fix regex lint warning")