### PR TITLE
virtme-ng: only match a single downloaded kernel on arm64

### DIFF
--- a/virtme_ng/mainline.py
+++ b/virtme_ng/mainline.py
@@ -25,7 +25,7 @@ class KernelDownloader:
         self.version = version
         self.arch = arch
         self.verbose = verbose
-        self.target = f"{self.kernel_dir}/boot/vmlinuz*generic*"
+        self.target = f"{self.kernel_dir}/boot/vmlinuz*generic"
 
         if not glob(self.target):
             self._fetch_kernel()


### PR DESCRIPTION
The glob currently matches two vmlinuz when using ubuntu mainline kernels: vmlinuz-6.6.51-060651-generic and
vmlinuz-6.6.51-060651-generic-64k ; but we only need one of the two, otherwise we'll fail with this error:

virtme-run: error: unrecognized arguments: /home/anisse/.cache/virtme-ng/v6.6.51/arm64/boot/vmlinuz-6.6.51-060651-generic-64k

At least this way it should work better, hopefully without breaking other architectures' vmlinuz detection.