### PR TITLE
virtme-ng: allow to specify multiple --rwdir and --rodir

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -868,12 +868,12 @@ class KernelSource:
     def _get_virtme_rodir(self, args):
         self.virtme_param["rodir"] = ""
         for item in args.rodir:
-            self.virtme_param["rodir"] += "--rodir " + item
+            self.virtme_param["rodir"] += f"--rodir {item} "
 
     def _get_virtme_rwdir(self, args):
         self.virtme_param["rwdir"] = ""
         for item in args.rwdir:
-            self.virtme_param["rwdir"] += "--rwdir " + item
+            self.virtme_param["rwdir"] += f"--rwdir {item} "
 
     def _get_virtme_overlay_rwdir(self, args):
         # Set default overlays if rootfs is mounted in read-only mode.


### PR DESCRIPTION
Allow to export multiple host directories as read-write or read-only into the guest.

This fixes issue #166.