### PR TITLE
virtme-init: Enable lvm usage

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -125,6 +125,11 @@ fi
 sed -e 's/^\([^:]\+\).*/\1:!:::::::/' < /etc/passwd > /run/tmp/shadow
 mount --bind /run/tmp/shadow /etc/shadow &
 
+# The /etc/lvm is usually only read/write by root. In order to allow commands like pvcreate to be
+# run on rootless users just create a dummy directory and bind mount it in the same place.
+mkdir /run/tmp/lvm
+mount --bind /run/tmp/lvm /etc/lvm
+
 # Find udevd
 if [[ -x /usr/lib/systemd/systemd-udevd ]]; then
     udevd=/usr/lib/systemd/systemd-udevd


### PR DESCRIPTION
Current /etc/lvm/ directories are restricted to root only (700), so just create an empty directory and bind mount over. This is enough to make commands like pvcreate to succeed.

It's the same commit as virtme-ng-init, but for virtme-init bash script. What do you think about this approach? Should we first check if the user is root before creating the bind mount?