### PR TITLE
 net: support multiple interfaces and different bridges

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -252,8 +252,11 @@ mount --bind "$tmpfile" "$real_sudoers"
 
 if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
     # udev is liable to rename the interface out from under us.
-    virtme_net=`ls "$(ls -d /sys/bus/virtio/drivers/virtio_net/virtio* |sort -g |head -n1)"/net`
-    busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
+    for d in /sys/bus/virtio/drivers/virtio_net/virtio*/net/*; do
+        virtme_net=$(basename "${d}")
+        busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname $0)/virtme-udhcpc-script" &
+    done
+    wait
 fi
 
 if cat /proc/cmdline |grep -q -E '(^| )virtme.snapd($| )'; then

--- a/virtme/guest/virtme-udhcpc-script
+++ b/virtme/guest/virtme-udhcpc-script
@@ -10,7 +10,9 @@ if [[ "$1" == "deconfig" ]]; then
     ip addr flush dev "$interface"
 elif [[ "$1" == "bound" ]]; then
     ip addr add "$ip/$mask" dev "$interface"
-    ip route add default via "$router" dev "$interface"
+    if [[ -n "$router" ]]; then
+        ip route add default via "$router" dev "$interface"
+    fi
     if [[ -n "$dns" ]]; then
 	# A lot of systems will have /etc/resolv.conf symlinked to
 	# /run/NetworkManager/something_or_other. Debian symlinks to /run/resolvconf.

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -349,8 +349,7 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "--network",
         "-n",
         action="append",
-        choices=['user', 'bridge', 'loop'],
-        help="Enable network access",
+        help="Enable network access: user, bridge(=<br>), loop",
     )
 
     parser.add_argument(


### PR DESCRIPTION
`virtme-run` supports multiple `--net` arguments to setup `virtio-net` devices, but the init program was only starting the DHCP client for one of them: the first one by alphabetical order.

Now, the DHCP client is started for each interface, so each of them can have an assigned IP address.

It is also now possible to specify the bridge interface, with `--net bridge=<br>` option, useful when there are multiple bridges that are created.

While at it, the udhcpc script no longer try to run a wrong command if no router is announced.

Note: this PR depends on https://github.com/arighi/virtme-ng-init/pull/12