### PR TITLE
feat: vsock support for remote console access

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,33 @@ Examples
    # vmlinux available in the system.
 ```
 
+ - Connect to a simple remote shell:
+```
+   # Start the vng instance with vsock support:
+   $ vng --vsock
+
+   # In a separate terminal run the following command to connect to a remote shell:
+   $ vng --vsock-connect
+```
+
+ - Connect to a remote shell with proper dimensions, env vars, and using 'Fish':
+```
+   # Start the vng instance with vsock support:
+   $ vng --vsock "${PWD}/console.sh"
+
+   # In a separate terminal run the following commands:
+   $ read -r rows columns <<< "$(stty size)"
+   $ cat <<-EOF > console.sh
+         #! /bin/bash
+         stty rows ${rows} columns ${columns}
+         cd "\${virtme_chdir}"
+         HOME=${HOME}
+         fish  # use use zsh, tmux, byobu, screen, etc.
+     EOF
+   $ chmod +x console.sh
+   $ vng --vsock-connect
+```
+
  - Run virtme-ng inside a docker container:
 ```
    $ docker run -it --privileged ubuntu:23.10 /bin/bash
@@ -449,7 +476,7 @@ Troubleshooting
   $ groups | grep "kvm\|libvirt"
 ```
 
- - When using `--net bridge` to create a bridged network in the guest you
+ - When using `--network bridge` to create a bridged network in the guest you
    may get the following error:
 ```
   ...

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -159,6 +159,9 @@ _GENERIC_CONFIG = [
     "CONFIG_ZONE_DEVICE=y",
     "CONFIG_FUSE_FS=y",
     "CONFIG_VIRTIO_FS=y",
+    "##: vsock support",
+    "CONFIG_VSOCKETS=y",
+    "CONFIG_VIRTIO_VSOCKETS=y",
 ]
 
 _GENERIC_CONFIG_OPTIONAL = [

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -275,6 +275,12 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.snapd($| )'; then
     fi
 fi
 
+vsock_exec=$(sed -ne "s/.*virtme.vsockexec=\`\(.*\)\`.*/\1/p" /proc/cmdline)
+if [[ -n "${vsock_exec}" ]]; then
+    socat "VSOCK-LISTEN:1024,reuseaddr,fork" \
+          "EXEC:\"${vsock_exec}\",pty,stderr,setsid,sigint,sane,echo=0" &
+fi
+
 user_cmd=$(sed -ne "s/.*virtme.exec=\`\(.*\)\`.*/\1/p" /proc/cmdline)
 if [[ -n "${user_cmd}" ]]; then
     if [[ ! -e "/dev/virtio-ports/virtme.stdin" ||

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -360,6 +360,28 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     parser.add_argument(
+        "--vsock",
+        action="store",
+        const="bash -i",
+        nargs="?",
+        help="Enable a VSock to communicate from the host to the device. "
+        + "An argument can be optionally specified to start a different shell.",
+    )
+
+    parser.add_argument(
+        "--vsock-cid",
+        action="store",
+        type=int,
+        help="CID for the VSock.",
+    )
+
+    parser.add_argument(
+        "--vsock-connect",
+        action="store_true",
+        help="Connect to a VM using VSock.",
+    )
+
+    parser.add_argument(
         "--disk",
         "-D",
         action="append",
@@ -947,6 +969,24 @@ class KernelSource:
         else:
             self.virtme_param["net_mac_address"] = ""
 
+    def _get_virtme_vsock(self, args):
+        if args.vsock is not None:
+            self.virtme_param["vsock"] = "--vsock '" + args.vsock + "'"
+        else:
+            self.virtme_param["vsock"] = ""
+
+    def _get_virtme_vsock_cid(self, args):
+        if args.vsock_cid is not None:
+            self.virtme_param["vsock_cid"] = "--vsock-cid " + str(args.vsock_cid)
+        else:
+            self.virtme_param["vsock_cid"] = ""
+
+    def _get_virtme_vsock_connect(self, args):
+        if args.vsock_connect:
+            self.virtme_param["vsock_connect"] = "--vsock-connect"
+        else:
+            self.virtme_param["vsock_connect"] = ""
+
     def _get_virtme_disk(self, args):
         if args.disk is not None:
             disk_str = ""
@@ -1102,6 +1142,9 @@ class KernelSource:
         self._get_virtme_mods(args)
         self._get_virtme_network(args)
         self._get_virtme_net_mac_address(args)
+        self._get_virtme_vsock(args)
+        self._get_virtme_vsock_cid(args)
+        self._get_virtme_vsock_connect(args)
         self._get_virtme_disk(args)
         self._get_virtme_sound(args)
         self._get_virtme_disable_microvm(args)
@@ -1141,6 +1184,9 @@ class KernelSource:
             + f'{self.virtme_param["mods"]} '
             + f'{self.virtme_param["network"]} '
             + f'{self.virtme_param["net_mac_address"]} '
+            + f'{self.virtme_param["vsock"]} '
+            + f'{self.virtme_param["vsock_cid"]} '
+            + f'{self.virtme_param["vsock_connect"]} '
             + f'{self.virtme_param["disk"]} '
             + f'{self.virtme_param["sound"]} '
             + f'{self.virtme_param["disable_microvm"]} '


### PR DESCRIPTION
Having a remote console access can be helpful for different reasons, e.g. an easy way to have multiple terminals, not using a serial which can be slow to print a lot of text, etc.

With this new support, a user can simply use vng like before, and add the new `--vsock` option:

    vng --vsock (...)

Then in another terminal, it can connect to the existing VM:

    vng --vsock-connect

Advanced users can set a different CID with `--vsock-cid`, useful when multiple VMs are started in parallel.

It is also possible to change the command that is executed when connected inside the VM. By default, `bash -i` is used, but it is possible to pass something else, e.g.

    vng --vsock byobu

Or zsh, fish, tmux, etc. Or a script, for example to set env vars, change dir and set other dimensions, etc., e.g. starting the VM with:

    $ vng --vsock "${PWD}/console.sh"

... and connecting to it from another terminal with:

    $ read -r rows columns <<< "$(stty size)"
    $ cat <<-EOF > console.sh
        #! /bin/bash
        stty rows ${rows} columns ${columns}
        cd "\${virtme_chdir}"
        HOME=${HOME}
        byobu
      EOF
    $ chmod +x console.sh
    $ vng --vsock-connect

Note: on my side, 'bash' is a bit weird: I cannot see the command I'm typing. I didn't try to find a solution for a too long time as I'm usually not using bash.

Regarding the kernel config, two new config are now required: `VSOCKETS` and `VIRTIO_VSOCKETS`. They seem light enough.

While at it, fixed a typo in the README file with the --network option.

Depends-on: #195

Link: https://github.com/arighi/virtme-ng/discussions/151