### PR TITLE
vsock: connect: support no tty, command with right user and no 'su'

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Examples
    # vmlinux available in the system.
 ```
 
- - Connect to a simple remote shell:
+ - Connect to a simple remote shell (`socat` is required):
 ```
    # Start the vng instance with vsock support:
    $ vng --vsock

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -887,7 +887,10 @@ def do_it() -> int:
             socat_in = '-'
         socat_out = f'VSOCK-CONNECT:{args.vsock_cid}:1024'
 
-        cmd = args.vsock_connect if args.vsock_connect else 'su ${virtme_user:-root}'
+        cmd = ''
+        if args.vsock_connect:
+            exec_escaped = args.vsock_connect.replace('"', '\\"')
+            cmd = f' -c "{exec_escaped}"'
 
         with open(vsock_script_path, 'w', encoding="utf-8") as file:
             print((
@@ -896,7 +899,7 @@ def do_it() -> int:
                 f'{stty}\n'
                 'HOME=$(getent passwd ${virtme_user:-root} | cut -d: -f6)\n'
                 'cd ${virtme_chdir:+"${virtme_chdir}"}\n'
-                f'exec {cmd}\n'
+                'exec su ${virtme_user}' f'{cmd}\n'
                 '}\n'
                 'main'  # use a function to avoid issues when the script is modified
             ), file=file)

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -889,6 +889,13 @@ def do_it() -> int:
 
         user = args.user if args.user else '${virtme_user:-root}'
 
+        if args.pwd:
+            cwd = os.path.relpath(os.getcwd(), args.root)
+        elif args.cwd is not None:
+            cwd = os.path.relpath(args.cwd, args.root)
+        else:
+            cwd = '${virtme_chdir:+"${virtme_chdir}"}'
+
         # use 'su' only if needed: another use, or to get a prompt
         cmd = f'if [ "{user}" != "root" ]; then\n' + \
               f'  exec su "{user}"'
@@ -908,7 +915,7 @@ def do_it() -> int:
                 'main() {\n'
                 f'{stty}\n'
                 f'HOME=$(getent passwd "{user}" | cut -d: -f6)\n'
-                'cd ${virtme_chdir:+"${virtme_chdir}"}\n'
+                f'cd {cwd}\n'
                 f'{cmd}\n'
                 '}\n'
                 'main'  # use a function to avoid issues when the script is modified

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -887,9 +887,11 @@ def do_it() -> int:
             socat_in = '-'
         socat_out = f'VSOCK-CONNECT:{args.vsock_cid}:1024'
 
+        user = args.user if args.user else '${virtme_user:-root}'
+
         # use 'su' only if needed: another use, or to get a prompt
-        cmd = 'if [ "${virtme_user:-root}" != "root" ]; then\n' + \
-              '  exec su ${virtme_user}'
+        cmd = f'if [ "{user}" != "root" ]; then\n' + \
+              f'  exec su "{user}"'
         if args.vsock_connect:
             exec_escaped = args.vsock_connect.replace('"', '\\"')
             cmd += f' -c "{exec_escaped}"' + \
@@ -905,7 +907,7 @@ def do_it() -> int:
                 '#! /bin/bash\n'
                 'main() {\n'
                 f'{stty}\n'
-                'HOME=$(getent passwd ${virtme_user:-root} | cut -d: -f6)\n'
+                f'HOME=$(getent passwd "{user}" | cut -d: -f6)\n'
                 'cd ${virtme_chdir:+"${virtme_chdir}"}\n'
                 f'{cmd}\n'
                 '}\n'

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1498,7 +1498,7 @@ def do_it() -> int:
             return 1
         kernelargs.append("virtme_chdir=%s" % rel_cwd)
 
-    if args.user:
+    if args.user and args.user != "root":
         kernelargs.append("virtme_user=%s" % args.user)
 
     if args.nvgpu:

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -136,7 +136,7 @@ def make_parser() -> argparse.ArgumentParser:
         nargs="?",
         metavar="COMMAND",
         const="",
-        help="Enable a VSock to communicate from the host to the device. "
+        help="Enable a VSock to communicate from the host to the device, 'socat' is required. "
         + "An argument can be optionally specified to start a different command.",
     )
     g.add_argument(

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -365,7 +365,7 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         nargs="?",
         metavar="COMMAND",
         const="",
-        help="Enable a VSock to communicate from the host to the device. "
+        help="Enable a VSock to communicate from the host to the device, 'socat' is required. "
         + "An argument can be optionally specified to start a different command.",
     )
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -852,16 +852,14 @@ class KernelSource:
         # sessions is current user.
         #
         # NOTE: graphic sessions are considered interactive.
+        self.virtme_param["user"] = ""
         if args.exec and not args.graphics:
             self.virtme_param["user"] = ""
         else:
             self.virtme_param["user"] = "--user " + get_username()
         # Override default user, if specified by the --user argument.
         if args.user is not None:
-            if args.user != "root":
-                self.virtme_param["user"] = "--user " + args.user
-            else:
-                self.virtme_param["user"] = ""
+            self.virtme_param["user"] = "--user " + args.user
 
     def _get_virtme_arch(self, args):
         if args.arch is not None:


### PR DESCRIPTION
Here are a few small improvements for the new `--vsock-connect` feature:
- support environments without tty, e.g. CI.
- execute commands with the right user, not root if the VM was launched with a different user.
- use `su` only if needed: to save ~0.5 sec when executing a command with root.
- `--user` is used if defined
- `--pwd` and `--cwd` are used if defined.