### PR TITLE
vsock: rename options to --client/--server

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Requirements
  * Optionally, you may need virtiofsd 1.7.0 (or higher) for better filesystem
    performance inside the virtme-ng guests.
 
+ * Optionally, you may need `socat` for the `--server` and `--client` options,
+   and the host's kernel should support VSOCK (`CONFIG_VHOST_VSOCK`).
+
 Examples
 ========
 

--- a/README.md
+++ b/README.md
@@ -345,13 +345,13 @@ Examples
    # vmlinux available in the system.
 ```
 
- - Connect to a simple remote shell (`socat` is required):
+ - Connect to a simple remote shell (`socat` is required, VSOCK will be used):
 ```
-   # Start the vng instance with vsock support:
-   $ vng --vsock
+   # Start the vng instance with server support:
+   $ vng --server
 
    # In a separate terminal run the following command to connect to a remote shell:
-   $ vng --vsock-connect
+   $ vng --client
 ```
 
  - Run virtme-ng inside a docker container:

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -924,7 +924,10 @@ def console_client(args):
         ), file=file)
     os.chmod(console_script_path, 0o755)
 
-    os.execvp('socat', ['socat', socat_in, socat_out])
+    if args.dry_run:
+        print('socat', socat_in, socat_out)
+    else:
+        os.execvp('socat', ['socat', socat_in, socat_out])
 
 
 def console_server(args, qemu, arch, qemuargs, kernelargs):

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -346,7 +346,7 @@ def make_parser() -> argparse.ArgumentParser:
         "--port",
         action="store",
         type=int,
-        default=3,
+        default=2222,
         help="Unique port to communicate with a VM.",
     )
     g.add_argument(

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -968,6 +968,9 @@ def do_it() -> int:
     args = _ARGPARSER.parse_args()
 
     if args.client is not None:
+        if args.server is not None:
+            arg_fail('--client cannot be used with --server.')
+
         console_client(args)
         sys.exit(0)
 


### PR DESCRIPTION
The idea is to have other types of remote connections later on, e.g. SSH. See the discussion on #204.

So to support future types later on, the syntax is now:

    vng --server|--client [console|ssh] [--port PORT] [--remote-cmd COMMAND]

The 'ssh' option is not available yet, but by default, 'console' will be used, so users can just do:

    $ vng --server
    $ vng --client  # in another terminal

A new group for the parser has been added to avoid confusions: `--port` and `--remote-cmd` are linked to `--client` / `--server`.

While at it, the code for the console client/server has been moved to dedicated functions, grouped together. It will also be easy to support a new type later on, simply by calling a different function.

Note that this should only be a refactoring, the behaviour, apart from different option name, should not be modified.

The variables names have been renamed too. 'vsock' is now only used in `virtme(-ng)-init` and in the `socat` command.

+ a few minor changes linked to these options.