### PR TITLE
github: restrict builds on push to the main branch

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,8 @@ name: Pylint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -2,6 +2,8 @@ name: Run
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Not to run the tests twice in a row.

When a branch from the upstream repo is used, the tests are duplicated in the PR: the ones for 'pull_request', and ones for 'push'.

With this modification, it means that the tests are no longer executed when something is pushed, but no PR are created. I guess that's fine, because when something is pushed, it is very likely to have a PR created just after (if it is not already the case).