### PR TITLE
virtme: enable ssh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,27 @@ Examples
    $ vng --client
 ```
 
+ - Enable ssh in the vng guest:
+```
+   # Start the vng instance with ssh server support:
+   $ vng --server ssh
+
+   # Connect to the vng guest from the host via ssh:
+   $ vng --client ssh
+```
+
+ - Generate some results inside the vng guest and copy them back to the
+   host using scp:
+```
+   # Start the vng instance with SSH server support:
+   arighi@host~> vng --server ssh
+   ...
+   arighi@virtme-ng~> ./run.sh > result.txt
+
+   # In another terminal, copy result.txt from the guest to the host using scp:
+   arighi@gpd3~> scp -P 2222 localhost:~/result.txt .
+```
+
  - Run virtme-ng inside a docker container:
 ```
    $ docker run -it --privileged ubuntu:23.10 /bin/bash

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ Requirements
  * Optionally, you may need virtiofsd 1.7.0 (or higher) for better filesystem
    performance inside the virtme-ng guests.
 
- * Optionally, you may need `socat` for the `--server` and `--client` options,
-   and the host's kernel should support VSOCK (`CONFIG_VHOST_VSOCK`).
+ * Optionally, you may need `socat` for the `--console` and
+   `--console-client` options, and the host's kernel should support VSOCK
+   (`CONFIG_VHOST_VSOCK`).
+
+ * Optionally, you may need `sshd` installed for the `--ssh` and
+   `--ssh-client` options.
 
 Examples
 ========
@@ -382,26 +386,26 @@ Examples
  - Connect to a simple remote shell (`socat` is required, VSOCK will be used):
 ```
    # Start the vng instance with server support:
-   $ vng --server
+   $ vng --console
 
    # In a separate terminal run the following command to connect to a remote shell:
-   $ vng --client
+   $ vng --console-client
 ```
 
  - Enable ssh in the vng guest:
 ```
    # Start the vng instance with ssh server support:
-   $ vng --server ssh
+   $ vng --ssh
 
    # Connect to the vng guest from the host via ssh:
-   $ vng --client ssh
+   $ vng --ssh-client
 ```
 
  - Generate some results inside the vng guest and copy them back to the
    host using scp:
 ```
    # Start the vng instance with SSH server support:
-   arighi@host~> vng --server ssh
+   arighi@host~> vng --ssh
    ...
    arighi@virtme-ng~> ./run.sh > result.txt
 

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ packages = [
 package_files = [
     "virtme-init",
     "virtme-udhcpc-script",
+    "virtme-sshd-script",
     "virtme-snapd-script",
     "virtme-sound-script",
 ]

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -257,6 +257,10 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
     wait
 fi
 
+if cat /proc/cmdline |grep -q -E '(^| )virtme.ssh($| )'; then
+    $(dirname $0)/virtme-sshd-script
+fi
+
 if cat /proc/cmdline |grep -q -E '(^| )virtme.snapd($| )'; then
     # If snapd is present in the system try to start it, to properly support snaps.
     snapd_bin="/usr/lib/snapd/snapd";

--- a/virtme/guest/virtme-sshd-script
+++ b/virtme/guest/virtme-sshd-script
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Initialize ssh server for remote connections (option `--server ssh`)
+
+if [ -z "${virtme_ssh_user}" ]; then
+    echo "ssh: virtme_ssh_user is not defined" >&2
+    exit 1
+fi
+
+SSH_HOME=$(getent passwd "${virtme_ssh_user}" | cut -d: -f6)
+if [ ! -e "${SSH_HOME}" ]; then
+    # Setup an arbitrary ssh location, just to be able to start sshd.
+    SSH_HOME=/run/ssh
+fi
+
+# Update authorized_keys by adding the user's public keys, but only if the
+# changes are confined to the guest (no modifications made to the host).
+#
+# Overwriting authorized_keys is considered safe only when the guest rootfs
+# is mounted as read-only, with an overlayfs on top to handle writes within
+# the guest environment (`--rw` not specified as argument).
+if grep ' / ' /proc/mounts | grep -q ' ro,'; then
+    cat "${SSH_HOME}"/.ssh/id_*.pub >> "${SSH_HOME}/.ssh/authorized_keys" 2>/dev/null
+    chown "${virtme_ssh_user}" "${SSH_HOME}/.ssh/authorized_keys" 2>/dev/null
+fi
+
+# Generate ssh host keys (if they don't exist already).
+CACHE_DIR=${SSH_HOME}/.cache/virtme-ng/.ssh
+mkdir -p "${CACHE_DIR}/etc/ssh"
+ssh-keygen -A -f "${CACHE_DIR}"
+ARGS=()
+for key in "${CACHE_DIR}"/etc/ssh/ssh_host_*_key; do
+    ARGS+=(-h "${key}")
+done
+
+# Start sshd.
+mkdir -p /run/sshd
+rm -f /var/run/nologin
+/usr/sbin/sshd "${ARGS[@]}"

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -487,7 +487,7 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     g_remote = parser.add_argument_group(title="Remote Console")
-    cli_srv_choices = ["console"]
+    cli_srv_choices = ["console", "ssh"]
 
     g_remote.add_argument(
         "--server",


### PR DESCRIPTION
Add support for specifying `--server ssh`, to automatically start and configure sshd in the virtme-ng guest, and `--client ssh` to connect to a virtme-ng guest via SSH.

The server's port can be customized with the `--port NUM` option (default is 2222).

Example usage (start a vng instance with sshd enabled):

 $ vng --server ssh --port 2222

In another shell session on the host, connect to the running instance as a client:

 $ vng --client ssh --port 2222

Note that it's also possible to use ssh or scp directly, the --client option is provided for convenience and to be consistent with the vsock option.

Edit: additionally, introduce the following shortcuts for convenience, to quickly enable remote connection (either vsock or ssh):

 $ vng --console PORT
 $ vng --ssh PORT

Example:
```
 $ vng --ssh

 # In another terminal
 $ ssh -p 2222 localhost
```