### PR TITLE
sshd: look for overlayfs before modifying auth keys

### DIFF
--- a/virtme/guest/virtme-sshd-script
+++ b/virtme/guest/virtme-sshd-script
@@ -18,10 +18,12 @@ fi
 #
 # Overwriting authorized_keys is considered safe only when the guest rootfs
 # is mounted as read-only, with an overlayfs on top to handle writes within
-# the guest environment (`--rw` not specified as argument).
-if grep ' / ' /proc/mounts | grep -q ' ro,'; then
-    cat "${SSH_HOME}"/.ssh/id_*.pub >> "${SSH_HOME}/.ssh/authorized_keys" 2>/dev/null
-    chown "${virtme_ssh_user}" "${SSH_HOME}/.ssh/authorized_keys" 2>/dev/null
+# the guest environment (e.g. `--rw` or `--rwdir` not specified as argument).
+OVERLAYFS="794c7630" # OVERLAYFS_SUPER_MAGIC in include/uapi/linux/magic.h
+SSH_AUTH_KEYS="${SSH_HOME}/.ssh/authorized_keys"
+if [ "$(stat -f -c "%t" "${SSH_AUTH_KEYS}")" = "${OVERLAYFS}" ]; then
+    cat "${SSH_HOME}"/.ssh/id_*.pub >> "${SSH_AUTH_KEYS}" 2>/dev/null
+    chown "${virtme_ssh_user}" "${SSH_AUTH_KEYS}" 2>/dev/null
 fi
 
 # Generate ssh host keys (if they don't exist already).


### PR DESCRIPTION
Only looking if the rootfs is in read-only might not be enough, e.g. if the home directory is mounted in RW.

Instead, we can simply check in which file-system the authorized_keys file is in: if it is in an overlayfs, it is safe.

Note that the '%T' format could be used with stat, but it looks like it is not working with busybox.