### PR TITLE
ssh: only export the port to localhost

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1002,7 +1002,7 @@ def ssh_server(args, arch, qemuargs, kernelargs):
 
     # Setup a port forward network interface for the guest.
     qemuargs.extend(["-device", "%s,netdev=ssh" % (arch.virtio_dev_type("net"))])
-    qemuargs.extend(["-netdev", "user,id=ssh,hostfwd=tcp::%d-:22" % args.port])
+    qemuargs.extend(["-netdev", "user,id=ssh,hostfwd=tcp:127.0.0.1:%d-:22" % args.port])
 
 
 # Allowed characters in mount paths.  We can extend this over time if needed.


### PR DESCRIPTION
It doesn't seem safe to expose the socket to everybody around.

Restrict it to localhost only.

Please note that it also means other users on the same machine can still connect to it. But they will need credentials / keys.

From this discussion: https://github.com/arighi/virtme-ng-init/pull/16#pullrequestreview-2526363654