### PR TITLE
virtme-ng-init: always check return code when executing bash

### DIFF
--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -975,7 +975,8 @@ fn setup_user_session() {
         Some(console) => console,
         None => {
             log!("failed to determine console");
-            Command::new("bash").arg("-l").exec();
+            let err = Command::new("bash").arg("-l").exec();
+            log!("failed to exec bash: {}", err);
             return;
         }
     };


### PR DESCRIPTION
Fix the following warning:

warning: unused return value of `exec` that must be used
   --> src/main.rs:978:13
    |
978 |             Command::new("bash").arg("-l").exec();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default

Moreover, check the return code in case exec() fails and log an explicit error before exiting.