### PR TITLE
properly quoting exec string to avoid breaking virtme-run invocation …

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -23,6 +23,7 @@ from subprocess import (
 )
 from select import select
 from pathlib import Path
+import shlex
 
 import argcomplete
 
@@ -876,7 +877,7 @@ class KernelSource:
         if args.envs:
             args.exec = " ".join(args.envs)
         if args.exec is not None:
-            self.virtme_param["exec"] = f'--script-sh "{args.exec}"'
+            self.virtme_param["exec"] = f'--script-sh {shlex.quote(args.exec)}'
         else:
             self.virtme_param["exec"] = ""
 


### PR DESCRIPTION
as requested, this PR fixes #221 by replacing the double quotes in the command string passed through --exec with a call to `shlex.quote`