### PR TITLE
virtme-ng: enable amd64 architecture support on non-x86 platforms

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -552,6 +552,13 @@ def arg_fail(message, show_usage=True):
 
 
 ARCH_MAPPING = {
+    "amd64": {
+        "qemu_name": "x86_64",
+        "linux_name": "x86_64",
+        "cross_compile": "x86_64-linux-gnu-",
+        "kernel_target": "bzImage",
+        "kernel_image": "bzImage",
+    },
     "arm64": {
         "qemu_name": "aarch64",
         "linux_name": "arm64",


### PR DESCRIPTION
As mentioned in issue #223, there is no reason to forbid the use of x86_64 as a non-native architecture, so add the proper definition to support x86_64 (building kernel and starting instances) on non-x86 machines.

For consistency with Debian/Ubuntu naming conventions used for other architectures, use amd64 to identify x86_64.

Link: https://lore.kernel.org/all/426d4476-e3b4-4a95-84a1-850015651ee6@kernel.org/
Suggested-by: Catalin Marinas <catalin.marinas@arm.com>