### PR TITLE
console/ssh: properly quote the remote cmd

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1048,7 +1048,7 @@ class KernelSource:
 
     def _get_virtme_remote_cmd(self, args):
         if args.remote_cmd is not None:
-            self.virtme_param["remote_cmd"] = "--remote-cmd '" + args.remote_cmd + "'"
+            self.virtme_param["remote_cmd"] = f"--remote-cmd {shlex.quote(args.remote_cmd)}"
         else:
             self.virtme_param["remote_cmd"] = ""
 


### PR DESCRIPTION
Without this, a command with simple quotes would be misinterpreted, e.g.

    $ vng --console-client --remote-cmd "echo 'foo bar'"
    virtme-run: error: unrecognized arguments: bar