### PR TITLE
Support `vng O=` in interactive mode

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -364,8 +364,8 @@ def do_it():
     makef = "Makefile"
 
     # Check if KBUILD_OUTPUT is defined and if it's a directory
-    config_dir = os.environ.get("KBUILD_OUTPUT", "")
-    if config_dir and os.path.isdir(config_dir):
+    config_dir = os.environ.get("KBUILD_OUTPUT")
+    if config_dir is not None and os.path.isdir(config_dir):
         config = os.path.join(config_dir, config)
         makef = os.path.join(config_dir, makef)
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -884,7 +884,7 @@ class KernelSource:
         envs = []
         for var in args.envs:
             if var.startswith("O="):
-                self.virtme_param["kdir"] = "--kdir ./" + var[2:]
+                self.virtme_param["kdir"] = "--kdir " + var[2:]
             else:
                 envs.append(var)
         if envs:

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -881,8 +881,14 @@ class KernelSource:
             self.virtme_param["name"] = "--name " + socket.gethostname()
 
     def _get_virtme_exec(self, args):
-        if args.envs:
-            args.exec = " ".join(args.envs)
+        envs = []
+        for var in args.envs:
+            if var.startswith("O="):
+                self.virtme_param["kdir"] = "--kdir ./" + var[2:]
+            else:
+                envs.append(var)
+        if envs:
+            args.exec = " ".join(envs)
         if args.exec is not None:
             self.virtme_param["exec"] = f'--script-sh {shlex.quote(args.exec)}'
         else:
@@ -976,12 +982,8 @@ class KernelSource:
                     sys.exit(1)
             else:
                 self.virtme_param["kdir"] = "--kimg " + args.run
-        else:
-            for var in args.envs:
-                if var.startswith("O="):
-                    self.virtme_param["kdir"] = "--kdir ./" + var[2:]
-            if self.virtme_param.get("kdir") is None:
-                self.virtme_param["kdir"] = "--kdir ./"
+        elif self.virtme_param.get("kdir") is None:
+            self.virtme_param["kdir"] = "--kdir ./"
 
     def _get_virtme_mods(self, args):
         if args.skip_modules or platform.system() != "Linux":

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -983,7 +983,10 @@ class KernelSource:
             else:
                 self.virtme_param["kdir"] = "--kimg " + args.run
         elif self.virtme_param.get("kdir") is None:
-            self.virtme_param["kdir"] = "--kdir ./"
+            kbuild_dir = os.environ.get("KBUILD_OUTPUT")
+            if kbuild_dir is None or not os.path.isdir(kbuild_dir):
+                kbuild_dir = "./"
+            self.virtme_param["kdir"] = "--kdir " + kbuild_dir
 
     def _get_virtme_mods(self, args):
         if args.skip_modules or platform.system() != "Linux":


### PR DESCRIPTION
When looking at the discussion #228, I noticed `vng O=my_dir/` was not working as expected: with `-v`, I could see the VM booting, then stopping right after.

That's because `virtme-run` was called with `--script-sh "O=my_dir/" --kdir=./my_dir/`, so simply setting an env var and exiting.

Now `virtme-run` will be called with `--kdir=my_dir/`, so without `--script-sh` and without the `./` prefix to allow full paths.