### PR TITLE
virtme_ng: run.py: Fix --qemu-opts option

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -427,7 +427,8 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     parser.add_argument(
         "--qemu-opts",
         "-o",
-        action="append",
+        nargs=argparse.REMAINDER,
+        metavar="OPTS...",
         help="Additional arguments for QEMU (can be used multiple times)"
         " or bundled together: --qemu-opts='...'",
     )


### PR DESCRIPTION
The current virtme-run --qemu-opts work, but the vng counterpart doesn't. This is because we don't specify the number of arguments it can receive, so it fails with:

./vng -r --memory 4G --qemu-opts -device virtio-net-pci,netdev=dev1,mac=9a:e8:e9:ea:eb:ec,id=net1,vectors=9,mq=on -netdev tap,id=dev1,vhost=on,script=/etc/qemu-ifup-switch,queues=4 ...
vng: error: argument --qemu-opts/-o: expected one argument

The fix is to apply the same nargs value from virtme-ng.