### PR TITLE
virtme: Fix guest dir presence check when --root is set

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1229,7 +1229,7 @@ def do_it() -> int:
         if not m:
             arg_fail("invalid --%s parameter %r" % (dirtype, dirarg))
         if m.group(2) is not None:
-            guestpath = m.group(1)
+            guestpath = os.path.join(args.root, os.path.relpath("/", m.group(1)))
             hostpath = m.group(2)
         else:
             hostpath = m.group(1)


### PR DESCRIPTION
I'm trying to work around https://github.com/arighi/virtme-ng/issues/236 by creating subdirectories in my guest's `/mnt` and mounting stuff there via virtiofs. I found that once I replaced my `--rodir=/mnt=/foo/bar` with `--rodir=/mnt/something=/foo/bar` I get this error:

```
error: cannot initialize /mnt/kselftest_install inside the guest (path must be defined inside a valid overlay)
```

This seems to be a leaked assumption that the guest and host rootfs are the same shape. That assumption is wrong when --root is set to something other than `/`.

The fix is just to calculate the path of the directory that needs to be mounted relative to the rootfs on the host, before checking if it exists.

Fixes https://github.com/arighi/virtme-ng/issues/237