### PR TITLE
init: allow to create raw ICMP socket as regular user

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -249,6 +249,10 @@ fi
 mount --bind "$tmpfile" "$real_sudoers"
 
 if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
+    # Make sure all GIDs are allowed to create raw ICMP sockets (this
+    # allows to run ping as regular user).
+    echo "0 2147483647" > /proc/sys/net/ipv4/ping_group_range
+
     # udev is liable to rename the interface out from under us.
     for d in /sys/bus/virtio/drivers/virtio_net/virtio*/net/*; do
         virtme_net=$(basename "${d}")

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -686,6 +686,15 @@ fn setup_network() -> Vec<Option<thread::JoinHandle<()>>> {
 
     let cmdline = std::fs::read_to_string("/proc/cmdline").unwrap();
     if cmdline.contains("virtme.dhcp") {
+        // Make sure all GIDs are allowed to create raw ICMP sockets (this allows to run ping as
+        // regular user).
+        if let Ok(mut file) = OpenOptions::new()
+            .write(true)
+            .open("/proc/sys/net/ipv4/ping_group_range")
+        {
+            let _ = file.write_all("0 2147483647".as_bytes());
+        }
+
         if let Some(guest_tools_dir) = get_guest_tools_dir() {
             get_network_devices().into_iter().for_each(|network_dev| {
                 vec.push(get_network_handle(


### PR DESCRIPTION
Starting a vng session as regular user doesn't allow to run ping:
```
 $ vng --network user
 ...
 $ ping -c1 localhost
 ping: socktype: SOCK_DGRAM
 ping: socket: Address family not supported by protocol
```
The reason is that by default the kernel restricts the GIDs that are allowed to create raw ICMP sockets:
```
 $ sysctl net.ipv4.ping_group_range
 net.ipv4.ping_group_range = 1	0
```
Increase the range of allowed GIDs, so that any regular user is able to run ping.

After this change:
```
 $ vng --network user
 ...
 $ ping -c1 localhost
 PING localhost (127.0.0.1) 56(84) bytes of data.
 64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.091 ms

 --- localhost ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 rtt min/avg/max/mdev = 0.091/0.091/0.091/0.000 ms
```

Reported-by: Joel Fernandes <joelagnelf@nvidia.com>