### PR TITLE
init: clean up previous X11 state

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -440,6 +440,9 @@ if [[ -n "${virtme_graphics}" ]]; then
         pre_exec_cmd=""
     fi
 
+    # Clean up any previous X11 state.
+    rm -f /tmp/.X11*/* /tmp/.X11-lock
+
     # Create a .xinitrc to start the requested graphical application.
     xinit_rc=/run/tmp/.xinitrc
     echo -e "${pre_exec_cmd}\nexec /run/tmp/.virtme-script" > ${xinit_rc}

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -921,6 +921,9 @@ fn run_user_gui(tty_fd: libc::c_int) {
         // directly here so we may need extra permissions on the tty devices.
         utils::run_cmd("bash", &["-c", &format!("chown {} /dev/char/*", user)]);
 
+        // Clean up any previous X11 state.
+        utils::run_cmd("bash", &["-c", &"rm -f /tmp/.X11*/* /tmp/.X11-lock"]);
+
         // Start xinit directly.
         storage = format!("su {} -c 'xinit /run/tmp/.xinitrc'", user);
         args.push(&storage);


### PR DESCRIPTION
When running vng in graphic mode (-g), recent versions of Xorg may fail to start with the following error:
```
 _XSERVTransSocketUNIXCreateListener: ...SocketCreateListener() failed
 _XSERVTransMakeAllCOTSServerListeners: server already running
 (EE)
 Fatal server error:
 (EE) Cannot establish any listening sockets - Make sure an X server isn't already running(EE)
```
This can happen because the host's /tmp is exposed to the guest and Xorg might get confused finding a previous state.

Fix by removing the Xorg state files before starting the X server in the vng guest.

Fixes: da5b586 ("virtme-ng: export real /tmp to guest")