### PR TITLE
setup.py: Build a static virtme-ng-init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,12 @@ if build_virtme_ng_init and not os.path.exists("virtme_ng_init/Cargo.toml"):
 # Always include standard site-packages to PYTHONPATH
 os.environ['PYTHONPATH'] = sysconfig.get_paths()['purelib']
 
+# Produce static Rust binaries.
+#
+# This is required to use the same virtme-ng-init across different root
+# filesystems (when `--root DIR` is used).
+os.environ["RUSTFLAGS"] = "-C target-feature=+crt-static " + os.environ.get("RUSTFLAGS", "")
+
 
 class BuildPy(build_py):
     def run(self):


### PR DESCRIPTION
When using vng on a filesystem different than the host's filesystem (when `--root DIR` is used) we may have a different glibc version or different libraries in general, that are not compatible with the pre-built virtme-ng-init.

To fix this build a static virtme-ng-init, so that it can be used across any rootfs.

This fixes #243.