### PR TITLE
run: Add '--disable-monitor'

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -294,6 +294,11 @@ def make_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fallback to the bash virtme-init (useful for debugging/development)",
     )
+    g.add_argument(
+        "--disable-monitor",
+        action="store_true",
+        help="Disable QEMU STDIO monitor"
+    )
 
     g = parser.add_argument_group(
         title="Guest userspace configuration"
@@ -1306,9 +1311,17 @@ def do_it() -> int:
         if args.verbose:
             kernelargs.extend(arch.earlyconsole_args())
 
-        qemuargs.extend(["-chardev", "stdio,id=console,signal=off,mux=on"])
+        qemuargs.extend(
+            [
+                "-chardev",
+                "stdio,id=console,signal=off,mux={}".format(
+                    "off" if args.disable_monitor else "on"
+                ),
+            ]
+        )
         qemuargs.extend(["-serial", "chardev:console"])
-        qemuargs.extend(["-mon", "chardev=console"])
+        if not args.disable_monitor:
+            qemuargs.extend(["-mon", "chardev=console"])
 
         kernelargs.extend(["virtme_console=" + arg for arg in arch.serial_console_args()])
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -286,6 +286,10 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     parser.add_argument(
+        "--disable-monitor", action="store_true", help="Disable QEMU STDIO monitor"
+    )
+
+    parser.add_argument(
         "--cwd",
         action="store",
         help="Change guest working directory "
@@ -1050,6 +1054,12 @@ class KernelSource:
         else:
             self.virtme_param["ssh"] = ""
 
+    def _get_virtme_disable_monitor(self, args):
+        if args.disable_monitor:
+            self.virtme_param["disable_monitor"] = "--disable-monitor"
+        else:
+            self.virtme_param["disable_monitor"] = ""
+
     def _get_virtme_ssh_client(self, args):
         if args.console_client is not None and args.ssh_client is not None:
             arg_fail('--console-client cannot be used with --ssh-client', show_usage=False)
@@ -1253,6 +1263,7 @@ class KernelSource:
         self._get_virtme_disk(args)
         self._get_virtme_sound(args)
         self._get_virtme_disable_microvm(args)
+        self._get_virtme_disable_monitor(args)
         self._get_virtme_disable_kvm(args)
         self._get_virtme_9p(args)
         self._get_virtme_initramfs(args)
@@ -1298,6 +1309,7 @@ class KernelSource:
             + f'{self.virtme_param["disk"]} '
             + f'{self.virtme_param["sound"]} '
             + f'{self.virtme_param["disable_microvm"]} '
+            + f'{self.virtme_param["disable_monitor"]} '
             + f'{self.virtme_param["disable_kvm"]} '
             + f'{self.virtme_param["force_9p"]} '
             + f'{self.virtme_param["force_initramfs"]} '


### PR DESCRIPTION
Note: I'm not sure how to name the command line option.

Sometimes the user is not interested in having a QEMU monitor, therefore let's add this option. This changes for example the 'CTRL-a' behavior on the console.