### PR TITLE
build: support newer pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [project]
+name = "virtme-ng"
+dynamic = ["version", "license", "authors", "dependencies", "readme", "description", "classifiers", "scripts"]
 requires-python = ">=3.8"
 
 [build-system]


### PR DESCRIPTION
Building vng using pip 25.0.1 triggers a bunch of errors. Update pyproject.toml to make pip happy.