### PR TITLE
pre-commit: Avoid removing the blank line from DCO-1.1.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
+        exclude: 'DCO-1\.1\.txt'
       - id: trailing-whitespace
       - id: check-merge-conflict
       - id: mixed-line-ending


### PR DESCRIPTION
This avoids to run the 'end-of-file-fixer' hook on the 'DCO-1.1.txt' file.

Before this change:

```
$ pre-commit run --all-files
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing DCO-1.1.txt
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
mixed line ending........................................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
pyupgrade................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

After this change:

```
$ pre-commit run --all-files
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
mixed line ending........................................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
pyupgrade................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```