### PR TITLE
configkernel: check for an existing .config before doing new one

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -291,6 +291,34 @@ def do_it():
     arch = architectures.get(args.arch)
     is_native = args.arch == platform.machine()
 
+    # Determine if an initial config is present
+    config = ".config"
+    makef = "Makefile"
+
+    # 1st check if make O= arg or KBUILD_OUTPUT is defined and if
+    # it's a directory; it would have the .config and Makefile
+
+    # make "O=..." takes precedence over KBUILD_OUTPUT.
+    for var in args.envs:
+        if var.startswith("O="):
+            os.environ["KBUILD_OUTPUT"] = var[2:]
+
+    config_dir = os.environ.get("KBUILD_OUTPUT")
+    if config_dir is not None:
+        try:
+            os.makedirs(config_dir, exist_ok=True)
+        except Exception as exc:
+            print(f"Error: invalid directory for KBUILD_OUTPUT: {config_dir}")
+            raise SilentError() from exc
+        config = os.path.join(config_dir, config)
+        makef = os.path.join(config_dir, makef)
+
+    if os.path.exists(config):
+        if args.no_update:
+            print(f"{config} file exists: no modifications have been done")
+            return 0
+
+    # else we make a fresh config
     custom_conf = []
     if args.custom:
         for conf_chunk in args.custom:
@@ -334,6 +362,9 @@ def do_it():
         gccname = shlex.quote(f"{cross_compile_prefix}-gcc")
         archargs.append(f"CROSS_COMPILE={gccname}")
 
+    for var in args.envs:
+        archargs.append(shlex.quote(var))
+
     maketarget: Optional[str]
 
     updatetarget = ""
@@ -351,34 +382,7 @@ def do_it():
     else:
         arg_fail("No mode selected")
 
-    # Propagate additional Makefile variables
-    for var in args.envs:
-        if var.startswith("O="):
-            # Setting "O=..." takes precedence over KBUILD_OUTPUT.
-            os.environ["KBUILD_OUTPUT"] = var[2:]
-
-        archargs.append(shlex.quote(var))
-
-    # Determine if an initial config is present
-    config = ".config"
-    makef = "Makefile"
-
-    # Check if KBUILD_OUTPUT is defined and if it's a directory
-    config_dir = os.environ.get("KBUILD_OUTPUT")
-    if config_dir is not None:
-        try:
-            os.makedirs(config_dir, exist_ok=True)
-        except Exception as exc:
-            print(f"Error: invalid directory for KBUILD_OUTPUT: {config_dir}")
-            raise SilentError() from exc
-        config = os.path.join(config_dir, config)
-        makef = os.path.join(config_dir, makef)
-
-    if os.path.exists(config):
-        if args.no_update:
-            print(f"{config} file exists: no modifications have been done")
-            return 0
-    else:
+    if not os.path.exists(config):
         if args.update:
             print(f"Error: {config} file is missing")
             return 1

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -19,6 +19,12 @@ from .. import architectures
 from ..util import SilentError
 
 
+def check_file_arg(filepath):
+    if not os.path.isfile(filepath):
+        raise argparse.ArgumentTypeError(f"'{filepath}' is not a valid file.")
+    return filepath
+
+
 def make_parser():
     parser = argparse.ArgumentParser(
         description="Configure a kernel for virtme",
@@ -42,6 +48,7 @@ def make_parser():
     parser.add_argument(
         "--custom",
         action="append",
+        type=check_file_arg,
         metavar="CUSTOM",
         help="Use a custom config snippet file to override specific config options",
     )


### PR DESCRIPTION
Currently, configkernel starts preparing a new config, and afterwards checks if one exists.  With --verbose, this is quite noisy, obscuring the "have .config, no changes made" message which follows.

Move the "wheres-config" code (both KBUILD_OUTPUT and make O=..) above the "gen-config" code to avoid the useless work and noise entirely.

Here it is, working for me:

```
jimc@frodo:~/projects/lx/wk-A$ vng -bv O=./buz
cmd: virtme-configkernel --defconfig --verbose --no-update O=./buz make[1]: Entering directory '/home/jimc/projects/lx/wk-A/buz' missing ./buz/Makefile, adding -f $src/Makefile
adding make_args: ['-f', '/home/jimc/projects/lx/wk-A/Makefile']
  GEN     Makefile
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
...
```

v2 pull up O=.. handling and archargs too