### PR TITLE
resources: replace pkg_resources by importlib_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,9 +154,6 @@ setup(
     install_requires=[
         "argcomplete",
         "requests",
-        # `pkg_resources` is removed in python 3.12, moved to setuptools.
-        #
-        # TODO: replace pkg_resources with importlib. # pylint: disable=fixme
         "setuptools",
     ],
     entry_points={

--- a/virtme/resources.py
+++ b/virtme/resources.py
@@ -7,18 +7,17 @@
 
 """Helpers to find virtme's guest tools and host scripts."""
 
-import os
 import shutil
 import subprocess
 
-import pkg_resources
+from importlib import resources as importlib_resources
 
 
 def find_guest_tools():
     """Return the path of the guest tools installed with the running virtme."""
 
-    if pkg_resources.resource_isdir(__name__, "guest"):
-        return pkg_resources.resource_filename(__name__, "guest")
+    if importlib_resources.files(__name__).joinpath("guest").is_dir():
+        return str(importlib_resources.files(__name__) / "guest")
 
     # No luck.  This is somewhat surprising.
     return None
@@ -27,9 +26,9 @@ def find_guest_tools():
 def find_script(name) -> str:
     # If we're running out of a source checkout, we can find scripts in the
     # 'bin' directory.
-    fn = pkg_resources.resource_filename(__name__, f"../bin/{name}")
-    if os.path.isfile(fn):
-        return fn
+    fn = importlib_resources.files(__name__) / "../bin" / name
+    if fn.is_file():
+        return str(fn)
 
     # Otherwise assume we're actually installed and in PATH.
     guess = shutil.which(name)

--- a/virtme/resources.py
+++ b/virtme/resources.py
@@ -9,15 +9,16 @@
 
 import shutil
 import subprocess
-
 from importlib import resources as importlib_resources
+
+import virtme
 
 
 def find_guest_tools():
     """Return the path of the guest tools installed with the running virtme."""
 
-    if importlib_resources.files(__name__).joinpath("guest").is_dir():
-        return str(importlib_resources.files(__name__) / "guest")
+    if importlib_resources.files(virtme).joinpath("guest").is_dir():
+        return str(importlib_resources.files(virtme) / "guest")
 
     # No luck.  This is somewhat surprising.
     return None
@@ -26,7 +27,7 @@ def find_guest_tools():
 def find_script(name) -> str:
     # If we're running out of a source checkout, we can find scripts in the
     # 'bin' directory.
-    fn = importlib_resources.files(__name__) / "../bin" / name
+    fn = importlib_resources.files(virtme) / "../bin" / name
     if fn.is_file():
         return str(fn)
 


### PR DESCRIPTION
pkg_resources has been deprecated in Python v3.12.

Switch to importlib_resources instead.

We only need the path, not to read from these resources. So hopefully, this simple conversion can be applied.

Link: https://importlib-resources.readthedocs.io/en/latest/migration.html