### PR TITLE
README.md: Improve `virtme-ng.conf` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,8 +518,8 @@ them in `~/.config/virtme-ng/virtme-ng.conf` under `default_opts` and then
 simply run `vng --build`.
 
 Example (always use an external build server called 'kathleen' and run make
-inside a build chroot called `chroot:lunar-amd64`). To do so, modify the
-`default_opts` sections in `~/.config/virtme-ng/virtme-ng.conf` as following:
+inside a build chroot called `chroot:lunar-amd64`). To do so, add the
+`default_opts` section in `~/.config/virtme-ng/virtme-ng.conf` as following:
 ```
 {
     "default_opts": {

--- a/README.md
+++ b/README.md
@@ -521,10 +521,12 @@ Example (always use an external build server called 'kathleen' and run make
 inside a build chroot called `chroot:lunar-amd64`). To do so, modify the
 `default_opts` sections in `~/.config/virtme-ng/virtme-ng.conf` as following:
 ```
-    "default_opts" : {
+{
+    "default_opts": {
         "build_host": "kathleen",
         "build_host_exec_prefix": "schroot -c chroot:lunar-amd64 --"
     },
+}
 ```
 
 Now you can simply run `vng --build` to build your kernel from the current


### PR DESCRIPTION
The syntax is incorrect for the given 'virtme-ng.conf' example in the README.md.