### PR TITLE
Add support for systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,36 @@ Examples
    Linux version 6.7.0-060700rc5-generic (kernel@kathleen) (x86_64-linux-gnu-gcc-13 (Ubuntu 13.2.0-7ubuntu1) 13.2.0, GNU ld (GNU Binutils for Ubuntu) 2.41) #202312102332 SMP PREEMPT_DYNAMIC Sun Dec 10 23:41:31 UTC 2023
 ```
 
+ - Run with systemd as init:
+```
+   $ sudo vng -r --systemd --exec "systemctl status | head"
+   ● virtme-ng
+      State: starting
+      Units: 392 loaded (incl. loaded aliases)
+      Jobs: 4 queued
+      Failed: 3 units
+      Since: Mon 2025-05-26 11:00:47 -03; 4s ago
+   systemd: 257.5+suse.8.gc10a66fb4d
+   Tainted: unmerged-bin
+      CGroup: /
+            ├─init.scope
+```
+
+ - Run with systemd as init in an external rootfs:
+```
+   $ vng -r --systemd --user root --root ./rootfs/sid --exec "systemctl status | head"
+   ● virtme-ng
+      State: degraded
+      Units: 273 loaded (incl. loaded aliases)
+      Jobs: 0 queued
+      Failed: 4 units
+      Since: Mon 2025-05-26 14:01:06 UTC; 2s ago
+   systemd: 257.5-2
+   Tainted: unmerged-bin
+      CGroup: /
+            ├─init.scope
+```
+
  - Run the current kernel creating a 1GB NUMA node with CPUs 0,1,3 assigned
    and a 3GB NUMA node with CPUs 2,4,5,6,7 assigned:
 ```
@@ -584,9 +614,16 @@ Troubleshooting
 ```
 
  - Snap support is still experimental and something may not work as expected
-   (keep in mind that virtme-ng will try to run snapd in a bare minimum system
-   environment without systemd), if some snaps are not running try to disable
-   apparmor, adding `--append="apparmor=0"` to the virtme-ng command line.
+   (keep in mind that, by default, virtme-ng will try to run snapd in a bare
+   minimum system environment without systemd), if some snaps are not running
+   try to disable apparmor, adding `--append="apparmor=0"` to the virtme-ng
+   command line.
+
+ - Systemd support (`--systemd`) is still experimental. If something does not
+   work for you, try masking the unit that is freezing, e.g. `--append
+   "systemd.mask=$PROBLEMATIC_UNIT"`. Be aware that you might also need `--user
+   root`, or if you're using your own `/` as ROOTFS, you may need to run vng
+   itself as root.
 
  - Running virtme-ng instances inside docker: in case of failures/issues,
    especially with stdin/stdout/stderr redirections, make sure that you have

--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ virtme-ng command, such as:
  $ ./vng --help
 ```
 
+Configuration
+=============
+
+* You may customize the default configuration by providing one of the
+  following, by order of preference: `$HOME/.config/virtme-ng/virtme-ng.conf`,
+  `$HOME/.virtme-ng.conf` or `/etc/virtme-ng.conf`. As a fallback for any
+  missing values, the default ones will be used.
+
+* The format of the file is JSON. Default values:
+```
+{
+    "default_opts": {},
+    "systemd": {
+        "masks": ["getty@"]
+    }
+}
+```
+
+
 Requirements
 ============
 
@@ -550,12 +569,12 @@ Default options
 Typically, if you always use virtme-ng with an external build server (e.g.,
 `vng --build --build-host REMOTE_SERVER --build-host-exec-prefix CMD`) you
 don't always want to specify these options, so instead, you can simply define
-them in `~/.config/virtme-ng/virtme-ng.conf` under `default_opts` and then
-simply run `vng --build`.
+them in your configuration file (refer to the [Configuration](#configuration)
+section) under `default_opts` and then simply run `vng --build`.
 
 Example (always use an external build server called 'kathleen' and run make
 inside a build chroot called `chroot:lunar-amd64`). To do so, add the
-`default_opts` section in `~/.config/virtme-ng/virtme-ng.conf` as following:
+`default_opts` section in your configuration file as following:
 ```
 {
     "default_opts": {
@@ -621,9 +640,10 @@ Troubleshooting
 
  - Systemd support (`--systemd`) is still experimental. If something does not
    work for you, try masking the unit that is freezing, e.g. `--append
-   "systemd.mask=$PROBLEMATIC_UNIT"`. Be aware that you might also need `--user
-   root`, or if you're using your own `/` as ROOTFS, you may need to run vng
-   itself as root.
+   "systemd.mask=$PROBLEMATIC_UNIT"` (refer to the
+   [Configuration](#configuration) section for a more permanent setup). Be
+   aware that you might also need `--user root`, or if you're using your own
+   `/` as ROOTFS, you may need to run vng itself as root.
 
  - Running virtme-ng instances inside docker: in case of failures/issues,
    especially with stdin/stdout/stderr redirections, make sure that you have

--- a/cfg/virtme-ng.conf
+++ b/cfg/virtme-ng.conf
@@ -1,4 +1,6 @@
 {
-    "default_opts" : {
+    "default_opts": {},
+    "systemd": {
+        "masks": ["getty@"]
     }
 }

--- a/cfg/virtme-ng.conf
+++ b/cfg/virtme-ng.conf
@@ -1,6 +1,0 @@
-{
-    "default_opts": {},
-    "systemd": {
-        "masks": ["getty@"]
-    }
-}

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ if build_virtme_ng_init:
     packages.append("virtme.guest.bin")
 
 data_files = [
-    ("/etc", ["cfg/virtme-ng.conf"]),
     ("/usr/share/bash-completion/completions", ["virtme-ng-prompt", "vng-prompt"]),
 ]
 if build_manpages:

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -32,6 +32,7 @@ from virtme_ng.utils import (
     SSH_DIR,
     VIRTME_SSH_DESTINATION_NAME,
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
+    get_conf,
 )
 
 from .. import architectures, mkinitramfs, modfinder, qemu_helpers, resources, virtmods
@@ -1311,10 +1312,11 @@ def do_it() -> int:
         kernelargs.append("luks=no")
         # disable auditd so there are no errors if the user lacks `--rw`
         kernelargs.append("audit=off")
-        # disable getty@, since we're forcing the use of serial-getty@
-        kernelargs.append("systemd.mask=getty@")
         kernelargs.extend(
             [f"console={console}" for console in arch.serial_console_args() or []],
+        )
+        kernelargs.extend(
+            [f"systemd.mask={unit}" for unit in get_conf("systemd.masks") or []]
         )
 
     if args.root == "/":

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -25,7 +25,9 @@ from time import sleep
 from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
 from virtme_ng.utils import (
+    CACHE_DIR,
     DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR,
+    SERIAL_GETTY_FILE,
     SSH_CONF_FILE,
     SSH_DIR,
     VIRTME_SSH_DESTINATION_NAME,
@@ -96,6 +98,11 @@ def make_parser() -> argparse.ArgumentParser:
     g = parser.add_argument_group(title="Common guest options")
     g.add_argument(
         "--root", action="store", default="/", help="Local path to use as guest root"
+    )
+    g.add_argument(
+        "--systemd",
+        action="store_true",
+        help="Execute systemd as init (EXPERIMENTAL)",
     )
     g.add_argument(
         "--rw",
@@ -1297,28 +1304,58 @@ def do_it() -> int:
     else:
         virtme_init_cmd = "virtme-init"
 
+    if args.systemd:
+        # disable systemd-fstab-generator so boot does not freeze while waiting for disks
+        kernelargs.append("fstab=no")
+        # disable systemd-cryptsetup-generator so it doesn't wait for encrypted disks
+        kernelargs.append("luks=no")
+        # disable auditd so there are no errors if the user lacks `--rw`
+        kernelargs.append("audit=off")
+        # disable getty@, since we're forcing the use of serial-getty@
+        kernelargs.append("systemd.mask=getty@")
+        kernelargs.extend(
+            [f"console={console}" for console in arch.serial_console_args() or []],
+        )
+
     if args.root == "/":
-        initcmds = [f"init={guest_tools_path}/{virtme_init_cmd}"]
+        if args.systemd:
+            initcmds = [
+                "init=/bin/sh",
+                "--",
+                "-c",
+                f"SYSTEMD_UNIT_PATH={CACHE_DIR}: exec /sbin/init;",
+            ]
+        else:
+            initcmds = [f"init={guest_tools_path}/{virtme_init_cmd}"]
     else:
         virtfs_config = VirtFSConfig(
             path=guest_tools_path,
             mount_tag="virtme.guesttools",
         )
         export_virtfs(qemu, arch, qemuargs, virtfs_config)
-        initcmds = [
-            "init=/bin/sh",
-            "--",
-            "-c",
-            ";".join(
-                [
-                    "mount -t tmpfs run /run",
-                    "mkdir -p /run/virtme/guesttools",
-                    "/bin/mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any "
-                    + "virtme.guesttools /run/virtme/guesttools",
-                    f"exec /run/virtme/guesttools/{virtme_init_cmd}",
-                ]
-            ),
+        initsh = [
+            "mount -t tmpfs run /run",
+            "mkdir -p /run/virtme/guesttools",
+            "/bin/mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any "
+            + "virtme.guesttools /run/virtme/guesttools",
         ]
+        if args.systemd:
+            virtfs_config = VirtFSConfig(
+                path=str(CACHE_DIR),
+                mount_tag="virtme.cache",
+            )
+            export_virtfs(qemu, arch, qemuargs, virtfs_config)
+            initsh.extend(
+                [
+                    "mkdir -p /run/virtme/cache",
+                    "/bin/mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any "
+                    + "virtme.cache /run/virtme/cache",
+                    "SYSTEMD_UNIT_PATH=/run/virtme/cache: exec /sbin/init",
+                ]
+            )
+        else:
+            initsh.append(f"exec /run/virtme/guesttools/{virtme_init_cmd}")
+        initcmds = ["init=/bin/sh", "--", "-c", "; ".join(initsh)]
 
     # Arrange for modules to end up in the right place
     if kernel.moddir is not None:
@@ -1401,12 +1438,15 @@ def do_it() -> int:
     if args.graphics is None and not args.script_sh and not args.script_exec:
         qemuargs.extend(["-echr", "1"])
 
-        # Redirect kernel errors to stderr, creating a separate console.
-        #
-        # If we don't have access to stderr via procfs (for example when
-        # running inside a container), print a warning and implicitly
-        # suppress the kernel errors redirection.
-        if can_access_file("/proc/self/fd/2"):
+        if args.systemd:
+            # Do nothing if `--systemd` is used, since it relies on the serial console
+            pass
+        elif can_access_file("/proc/self/fd/2"):
+            # Redirect kernel errors to stderr, creating a separate console.
+            #
+            # If we don't have access to stderr via procfs (for example when
+            # running inside a container), print a warning and implicitly
+            # suppress the kernel errors redirection.
             qemuargs.extend(["-chardev", "file,path=/proc/self/fd/2,id=dmesg"])
             qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
             qemuargs.extend(["-device", "virtconsole,chardev=dmesg"])
@@ -1842,6 +1882,28 @@ def do_it() -> int:
     # Load a normal kernel
     qemuargs.extend(["-kernel", kernel.kimg])
     if kernelargs:
+        if args.systemd:
+            init_environment_vars = []
+            for arg in kernelargs:
+                match = re.match(r"(virtme_.*)=(.*)", arg)
+                if not match:
+                    continue
+                init_environment_vars.append(f"{match.group(1)}={match.group(2)}")
+            os.makedirs(CACHE_DIR, exist_ok=True)
+            with open(SERIAL_GETTY_FILE, "w", encoding="utf-8") as f:
+                f.write(
+                    f"""[Service]
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+Environment={shlex.join(init_environment_vars)}"""
+                )
+                if args.root == "/":
+                    f.write(f"\nExecStart={guest_tools_path}/{virtme_init_cmd}")
+                else:
+                    f.write(f"\nExecStart=/run/virtme/guesttools/{virtme_init_cmd}")
         qemuargs.extend(["-append", " ".join(quote_karg(a) for a in kernelargs)])
     if initrdpath is not None:
         qemuargs.extend(["-initrd", initrdpath])

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -19,9 +19,12 @@ log() {
 mount -t proc -o nosuid,noexec,nodev proc /proc/
 mount -t sysfs -o nosuid,noexec,nodev sys /sys/
 
-if ! grep -q "run /run" /proc/mounts; then
-    # Mount tmpfs dirs
-    mount -t tmpfs -o mode=0755 run /run/
+if [[ $$ -eq 1 ]]; then
+    # only mount /run if systemd is not the init
+    if ! grep -q "run /run" /proc/mounts; then
+        # Mount tmpfs dirs
+        mount -t tmpfs -o mode=0755 run /run/
+    fi
 fi
 mkdir /run/tmp
 

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -19,8 +19,10 @@ log() {
 mount -t proc -o nosuid,noexec,nodev proc /proc/
 mount -t sysfs -o nosuid,noexec,nodev sys /sys/
 
-# Mount tmpfs dirs
-mount -t tmpfs -o mode=0755 run /run/
+if ! grep -q "run /run" /proc/mounts; then
+    # Mount tmpfs dirs
+    mount -t tmpfs -o mode=0755 run /run/
+fi
 mkdir /run/tmp
 
 # Setup rw filesystem overlays

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -29,7 +29,7 @@ import argcomplete
 
 from virtme.util import SilentError, get_username
 from virtme_ng.mainline import KernelDownloader
-from virtme_ng.utils import CONF_FILE, spinner_decorator
+from virtme_ng.utils import get_conf, spinner_decorator
 from virtme_ng.version import VERSION
 
 
@@ -681,31 +681,8 @@ class KernelSource:
 
     def __init__(self):
         self.virtme_param = {}
-        conf_path = self.get_conf_file_path()
-        self.default_opts = []
-        if conf_path is not None:
-            with open(conf_path, encoding="utf-8") as conf_fd:
-                conf_data = json.loads(conf_fd.read())
-                if "default_opts" in conf_data:
-                    self.default_opts = conf_data["default_opts"]
+        self.default_opts = get_conf("default_opts")
         self.cpus = str(os.cpu_count())
-
-    def get_conf_file_path(self):
-        """Return virtme-ng main configuration file path."""
-
-        # First check if there is a config file in the user's home config
-        # directory, then check for a single config file in ~/.virtme-ng.conf and
-        # finally check for /etc/virtme-ng.conf. If none of them exist, report an
-        # error and exit.
-        configs = (
-            CONF_FILE,
-            Path(Path.home(), ".virtme-ng.conf"),
-            Path("/etc", "virtme-ng.conf"),
-        )
-        for conf in configs:
-            if conf.exists():
-                return conf
-        return None
 
     def _format_cmd(self, cmd):
         return shlex.split(cmd)

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -556,6 +556,12 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         + "or to launch this command instead of a prompt (--client).",
     )
 
+    parser.add_argument(
+        "--systemd",
+        action="store_true",
+        help="Execute systemd as init (EXPERIMENTAL)",
+    )
+
     return parser
 
 
@@ -948,6 +954,12 @@ class KernelSource:
         else:
             self.virtme_param["root"] = ""
 
+    def _get_virtme_systemd(self, args):
+        if args.systemd:
+            self.virtme_param["systemd"] = "--systemd"
+        else:
+            self.virtme_param["systemd"] = ""
+
     def _get_virtme_rw(self, args):
         if args.rw:
             self.virtme_param["rw"] = "--rw"
@@ -1301,6 +1313,7 @@ class KernelSource:
         self._get_virtme_user(args)
         self._get_virtme_arch(args)
         self._get_virtme_root(args)
+        self._get_virtme_systemd(args)
         self._get_virtme_rw(args)
         self._get_virtme_rodir(args)
         self._get_virtme_rwdir(args)
@@ -1349,6 +1362,7 @@ class KernelSource:
             + f"{self.virtme_param['user']} "
             + f"{self.virtme_param['arch']} "
             + f"{self.virtme_param['root']} "
+            + f"{self.virtme_param['systemd']} "
             + f"{self.virtme_param['rw']} "
             + f"{self.virtme_param['rodir']} "
             + f"{self.virtme_param['rwdir']} "

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -3,6 +3,7 @@
 
 """virtme-ng: configuration path."""
 
+import json
 from pathlib import Path
 
 from virtme_ng.spinner import Spinner
@@ -28,3 +29,31 @@ def spinner_decorator(message):
         return wrapper
 
     return decorator
+
+
+def get_conf_file_path():
+    """Return virtme-ng main configuration file path."""
+
+    # First check if there is a config file in the user's home config
+    # directory, then check for a single config file in ~/.virtme-ng.conf and
+    # finally check for /etc/virtme-ng.conf. If none of them exist, report an
+    # error and exit.
+    configs = (
+        CONF_FILE,
+        Path(Path.home(), ".virtme-ng.conf"),
+        Path("/etc", "virtme-ng.conf"),
+    )
+    for conf in configs:
+        if conf.exists():
+            return conf
+    return None
+
+
+def get_conf(name):
+    conf_path = get_conf_file_path()
+    if conf_path is not None:
+        with open(conf_path, encoding="utf-8") as conf_fd:
+            conf_data = json.loads(conf_fd.read())
+            if name in conf_data:
+                return conf_data[name]
+    return []

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -14,9 +14,11 @@ SSH_CONF_FILE = SSH_DIR.joinpath("virtme-ng-ssh.conf")
 VIRTME_SSH_DESTINATION_NAME = "virtme-ng"
 VIRTME_SSH_HOSTNAME_CID_SEPARATORS = ("%", "/")
 DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR = VIRTME_SSH_HOSTNAME_CID_SEPARATORS[0]
-SERIAL_GETTY_FILE = Path(CACHE_DIR, "serial-getty@.service")
 CONF_PATH = Path(Path.home(), ".config", "virtme-ng")
 CONF_FILE = Path(CONF_PATH, "virtme-ng.conf")
+SERIAL_GETTY_FILE = Path(CACHE_DIR, "serial-getty@.service")
+
+# NOTE: this must stay in sync with README.md
 CONF_DEFAULT = {
     "default_opts": {},
     "systemd": {

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -15,6 +15,7 @@ VIRTME_SSH_HOSTNAME_CID_SEPARATORS = ("%", "/")
 DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR = VIRTME_SSH_HOSTNAME_CID_SEPARATORS[0]
 CONF_PATH = Path(Path.home(), ".config", "virtme-ng")
 CONF_FILE = Path(CONF_PATH, "virtme-ng.conf")
+SERIAL_GETTY_FILE = Path(CACHE_DIR, "serial-getty@.service")
 
 
 def spinner_decorator(message):

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -49,11 +49,24 @@ def get_conf_file_path():
     return None
 
 
-def get_conf(name):
+def get_conf(key_path):
+    """Return a configured value for a key_path, which might be nested
+
+    >>> get_conf("default_opts")
+    {}
+    """
     conf_path = get_conf_file_path()
-    if conf_path is not None:
-        with open(conf_path, encoding="utf-8") as conf_fd:
-            conf_data = json.loads(conf_fd.read())
-            if name in conf_data:
-                return conf_data[name]
-    return []
+    if conf_path is None:
+        return None
+
+    keys = key_path.split(".")
+
+    with open(conf_path, encoding="utf-8") as conf_fd:
+        conf = json.loads(conf_fd.read())
+        try:
+            for key in keys:
+                conf = conf[key]
+            return conf
+        except (KeyError, TypeError):
+            print(f"WARNING: Key {key_path} not found in {conf_path}.")
+            return []

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -54,6 +54,10 @@ def get_conf(key_path):
 
     >>> get_conf("default_opts")
     {}
+    >>> get_conf("systemd")
+    {'masks': ["getty@"]}
+    >>> get_conf("systemd.masks")
+    ["getty@"]
     """
     conf_path = get_conf_file_path()
     if conf_path is None:


### PR DESCRIPTION
Hello!

First of all, I'm using vng for testing local builds of [LTP](https://github.com/linux-test-project/ltp) and it's such an amazing tool! Thank you for maintaining it!

One of these days I was trying to run a test which required systemd and realized it was unfortunately not the right tool for the job... Then I saw mentions of adding support for it [here](https://lwn.net/Articles/951313/) and [here](https://github.com/arighi/virtme-ng/discussions/193). I would like to get the ball rolling on this, but I didn't know where to start. I hacked away a very ugly solution and would like to ask for guidance about how to approach this problem and refine it.

Basically, the idea is to add a `--systemd` option argument (that only makes sense currently when in use with `--root`) which would then make sure `/sbin/init` is called instead of `/run/virtme/guesttools/{virtme_init_cmd}`. After the initial systemd setup, we call virtme_init_cmd through a patched serial-getty.service (this way, we are free to keep using `--exec`). Also, we  need to make sure that virtme_init_cmd does not try to do anything that systemd already did.

Sorry for pushing this half-baked ""solution"" but I'd like some comments :)

Thanks in advance,
        rbm

EDIT: For testing, I've been using this: `vng --run . --root /path/to/debian/rootfs/ --rw --systemd`