### PR TITLE
console: abort if socat is not available

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -952,6 +952,9 @@ def get_console_path(port):
 
 
 def console_client(args):
+    if which("socat") is None:
+        arg_fail("socat tool is required, but not available")
+
     try:
         # with tty support
         (cols, rows) = os.get_terminal_size()


### PR DESCRIPTION
'socat' is used to connect to the guest via VSOCK.

Instead of throwing a FileNotFoundError exception because 'socat' is not available, abort before with a more comprehensive message.