### PR TITLE
virtme/commands/run: Do not fail if nr_open can't be accessed

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1189,9 +1189,10 @@ def do_it() -> int:
     try:
         with open("/proc/sys/fs/nr_open", encoding="utf-8") as file:
             nr_open = file.readline().strip()
-            kernelargs.append(f"nr_open={nr_open}")
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         pass
+    else:
+        kernelargs.append(f"nr_open={nr_open}")
 
     # Parse NUMA settings.
     if args.numa:


### PR DESCRIPTION
When running in a container with limited privileges, some procfs files may be inaccessible (e.g., /proc/sys/fs/nr_open), triggering permission denied errors.

In such cases, ignore the error and continue, so that we can still get a functional vng session.