### PR TITLE
setup: fix license format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
     author_email="arighi@nvidia.com",
     description="Build and run a kernel inside a virtualized snapshot of your live system",
     url="https://github.com/arighi/virtme-ng",
-    license="GPLv2",
+    license="GPL-2.0-only",
     long_description=open(
         os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8"
     ).read(),
@@ -178,7 +178,6 @@ setup(
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: POSIX :: Linux",
     ],
     zip_safe=False,


### PR DESCRIPTION
With Python 3.13, I get these warnings when running `make`:

```
/usr/lib/python3/dist-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v2 (GPLv2)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/usr/lib/python3/dist-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v2 (GPLv2)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

Simply removing the mentioned classifiers line and use the proper SPDX expression, as recommended by the warnings, fixed the issues.