### PR TITLE
virtme_ng/utils: resolve symlinks for binary paths

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -937,7 +937,9 @@ def is_statically_linked(binary_path):
     try:
         # Run the 'file' command on the binary and check for the string
         # "statically linked"
-        result = subprocess.check_output(["file", binary_path], universal_newlines=True)
+        result = subprocess.check_output(
+            ["file", "-L", binary_path], universal_newlines=True
+        )
         return "statically linked" in result
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
Fedora 42 ships with busybox as a symlink:

 $ which busybox
 /usr/sbin/busybox
 $ ll /usr/sbin/busybox
 [...] /usr/sbin/busybox -> ../bin/busybox

This leads to false positive:

  virtme-run: a statically linked busybox could not be found, please install busybox-static