### PR TITLE
gdb: dry-run: use 'shlex' to print array

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1179,7 +1179,7 @@ def do_it() -> int:
             vmlinux = f"/usr/lib/debug/boot/vmlinux-{kernel.version}"
         command = ["gdb", "-q", "-ex", "target remote localhost:1234", vmlinux]
         if args.dry_run:
-            print(" ".join(command))
+            print(shlex.join(command))
         else:
             os.execvp("gdb", command)
         sys.exit(0)


### PR DESCRIPTION
Even if it is unlikely to have spaces in this command (maybe the kernel dir?), it seems better to use 'shlex' like it is done for the other commands.