### PR TITLE
virtme/commands/run: also identify static PIE busybox binaries

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -940,7 +940,7 @@ def is_statically_linked(binary_path):
         result = subprocess.check_output(
             ["file", "-L", binary_path], universal_newlines=True
         )
-        return "statically linked" in result
+        return "statically linked" in result or "static-pie linked" in result
     except subprocess.CalledProcessError:
         return False
 


### PR DESCRIPTION
Static busybox binaries may also be PIE executables, in which case the string that shows in command 'file -L' may include 'static-pie linked':

/bin/busybox.static: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), \
  static-pie linked, BuildID[sha1]=d8ddaf19d360bb5bb79931f41e977e268c47bdc8, stripped