### PR TITLE
virtme_ng_init: Fix potential endless loop when reading /proc/consoles

### DIFF
--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -229,8 +229,7 @@ fn get_legacy_active_console() -> Option<String> {
         Ok(file) => {
             let reader = BufReader::new(file);
 
-            // .flatten() ignores lines with reading errors
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 if line.chars().nth(27) == Some('C') {
                     let console = line.split(' ').next()?;
                     return Some(format!("/dev/{console}"));


### PR DESCRIPTION
Using flatten() on BufRead::lines() discards I/O errors but does not stop the iterator, potentially leading to infinite loop.

Fix by replacing `.flatten()` with `.map_while(Result::ok)`, which converts `Ok` values and terminates the iteration at the first `Err`.

This also fixes the following warning reported by cargo clippy:
```
 warning: flatten() will run forever if the iterator repeatedly produces an Err
```