### PR TITLE
README: rework the Installation section and a few more details

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,4 +700,3 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>
 
 [korg-web]: https://git.kernel.org/cgit/utils/kernel/virtme/virtme.git "virtme on kernel.org"
 [korg-git]: git://git.kernel.org/pub/scm/utils/kernel/virtme/virtme.git "git address"
-[virtme]: https://github.com/amluto/virtme "virtme"


### PR DESCRIPTION
I recently presented virtme-ng to a new colleague using Fedora, and I noticed the Installation section was no longer up-to-date.

I initially wanted to add the `pip` command in the README, but I ended up doing a bit more while at it :)

[Preview](https://github.com/matttbe/virtme-ng/tree/readme-install?tab=readme-ov-file#what-is-virtme-ng) vs [original](https://github.com/arighi/virtme-ng?tab=readme-ov-file#what-is-virtme-ng).

Note: I don't know if the colours make sense in all code blocks, but personally, that doesn't really chock me. Up to you guys.