### PR TITLE
commands: run.py: Resolve symlinks on get_kernel_version

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import termios
 from base64 import b64encode
+from pathlib import Path
 from shutil import which
 from time import sleep
 from typing import Any, Dict, List, NoReturn, Optional, Tuple
@@ -451,7 +452,10 @@ def get_rootfs_from_kernel_path(path):
     return os.path.abspath(path)
 
 
-def get_kernel_version(path, img_name: Optional[str] = None):
+def get_kernel_version(orig_path, img_name: Optional[str] = None):
+    # Resolve symlinks first
+    path = Path(orig_path).resolve()
+
     if not os.path.exists(path):
         arg_fail(f"kernel file {path} does not exist, try --build to build the kernel")
     if not os.access(path, os.R_OK):


### PR DESCRIPTION
In distributions like openSUSE/SLE, vmlinuz files can be just symlinks pointing to the real file elsewhere, like the example below:

$ file /boot/vmlinuz
/boot/vmlinuz: symbolic link to vmlinuz-6.16.3-1-default

In such cases, the detection of the kernel version may fail to find the kernel version, and thus not setting up the kernel modules, making the boot to fail. This happens because one of the detections rely on the output of the file command, which shows the kernel version if the file is a regular file:

$ file /usr/lib/modules/6.16.3-1-default/vmlinuz | grep version /usr/lib/modules/6.16.3-1-default/vmlinuz: Linux kernel x86 boot executable, bzImage, version 6.16.3-1-default...

Now, if the user runs vng -r /boot/vmlinuz, it can fail because the output of the file command is different:

$ file /boot/vmlinuz
/boot/vmlinuz: symbolic link to vmlinuz-6.16.3-1-default

The fix resolves the symlink, so vng can have the output it wants. It doesn't change the rationale of the detect, just avoids one corner case.