### PR TITLE
virtme-ng: Run virtiofsd with -o cache=always to avoid ESTALE errors

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -746,7 +746,7 @@ class VirtioFS:
             stderr = ""
         os.system(
             f"{virtiofsd_path} --syslog --no-announce-submounts "
-            + f"--socket-path {self.sock} --shared-dir {path} --sandbox none {stderr} &"
+            + f"--socket-path {self.sock} --shared-dir {path} --sandbox none {stderr} -o cache=always &"
         )
         max_attempts = 5
         check_duration = 0.1


### PR DESCRIPTION
When files are modified or replaced on the host, the guest may hit "Stale file handle" (ESTALE) errors when accessing them through virtiofs. This happens because virtiofsd revalidates inode and attribute information with the host on every access, and the guest ends up holding references to inodes that no longer exist.

Run virtiofsd with `-o cache=always` to address this. In this mode, inode and attribute metadata are always cached in the guest and never revalidated with the host. This prevents the guest from observing stale handles, since it no longer sees the underlying inode changes.

This effectively masks the ESTALE errors at the cost of weaker coherency: host-side file replacements may not be immediately visible to the guest, but for most use cases this trade-off is acceptable.

Fixes: https://github.com/arighi/virtme-ng/issues/187