### PR TITLE
virtme-ng: Introduce --shell

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -486,8 +486,13 @@ if [[ -n ${virtme_graphics} ]]; then
     fi
     # Drop to console if the graphical app failed.
 fi
+
 if [[ -n ${virtme_user} ]]; then
-    setsid bash -c "su -- ${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
+    shell=""
+    if [[ -n ${virtme_shell} ]]; then
+        shell="-s ${virtme_shell}"
+    fi
+    setsid bash -c "su ${shell} -- ${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
 else
     setsid bash 0<> "/dev/$consdev" 1>&0 2>&0
 fi

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -260,6 +260,13 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     parser.add_argument(
+        "--shell",
+        metavar="BINARY",
+        action="store",
+        help="Override the default user shell",
+    )
+
+    parser.add_argument(
         "--root",
         action="store",
         help="Pass a specific chroot to use inside the virtualized kernel "
@@ -1177,6 +1184,7 @@ class KernelSource:
 
     def _get_virtme_append(self, args):
         append = []
+
         if args.append is not None:
             for item in args.append:
                 split_items = shlex.split(item)
@@ -1184,6 +1192,11 @@ class KernelSource:
                     append += ["-a", split_item]
         if args.debug:
             append += ["-a", "nokaslr"]
+
+        # Set default user's shell override, if specified.
+        if args.shell is not None:
+            append += ["-a", "virtme_shell=" + args.shell]
+
         self.virtme_param["append"] = shlex.join(append)
 
     def _get_virtme_memory(self, args):

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -947,13 +947,23 @@ fn init_xdg_runtime_dir(uid: u32) {
 }
 
 fn run_user_shell(tty_fd: libc::c_int) {
-    let mut args = vec!["-l"];
-    let storage;
+    let mut args = vec![];
+    let cmd;
+
     if let Ok(user) = env::var("virtme_user") {
+        // Check if a shell override is defined.
+        let virtme_shell = env::var("virtme_shell").ok();
+
+        cmd = if let Some(shell) = virtme_shell {
+            format!("su -s {} -- {}", shell, user)
+        } else {
+            format!("su -- {}", user)
+        };
+
         args.push("-c");
-        storage = format!("su -- {user}");
-        args.push(&storage);
+        args.push(&cmd);
     }
+
     print_logo();
     run_shell(tty_fd, &args);
 }


### PR DESCRIPTION
Introduce a `--shell` option to override the default shell from `/etc/passwd` when launching a user session inside the vng guest.

This allows starting the guest session with an alternative shell or program (i.e., tmux).

Example:
```
  $ vng --shell /bin/bash
  ...
  $ echo $SHELL
  /bin/bash

  $ vng --shell /bin/fish
  ...
  > echo $SHELL
  /bin/fish
```

This addresses issue #346.