### PR TITLE
virtme: systemd: Disable zram service

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1323,6 +1323,8 @@ def do_it() -> int:
         kernelargs.append("luks=no")
         # disable auditd so there are no errors if the user lacks `--rw`
         kernelargs.append("audit=off")
+        # disable zram-generator: may hang at boot if CONFIG_ZRAM is not enabled
+        kernelargs.append("systemd.zram=0")
         kernelargs.extend(
             [f"console={console}" for console in arch.serial_console_args() or []],
         )


### PR DESCRIPTION
Kernels built with the default virtme-ng configuration lack zram support, so starting the zram service can hang the systemd boot.

Prevent the hang by implicitly disabling the zram service (system.zram=0).

This fixes a boot hang issue in CachyOS when using --systemd.