### PR TITLE
virtme/commands/run: Fix TypeError

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -488,10 +488,10 @@ def get_kernel_version(orig_path, img_name: Optional[str] = None):
     # The version detection fails s390x using file or strings tools, so check
     # if the file itself contains the version number.
     if img_name is not None:
-        match = re.search(rf"{img_name}-({version_pattern})", path)
+        match = re.search(rf"{img_name}-({version_pattern})", str(path))
         if match:
             return match.group(1)
-        match = re.search(rf"/lib/modules/({version_pattern})/{img_name}", path)
+        match = re.search(rf"/lib/modules/({version_pattern})/{img_name}", str(path))
         if match:
             return match.group(1)
 


### PR DESCRIPTION
`re.search(...)` expects a string as the second argument, therefore let's convert the Path into a string.

  $ ./vng -r
  Traceback (most recent call last):
    File "/home/mhartmay/storage/git/virtme-ng/virtme-run", line 18, in <module>
      sys.exit(run.main())
               ^^^^^^^^^^
    File "/home/mhartmay/storage/git/virtme-ng/virtme/commands/run.py", line 2028, in main
      return do_it()
             ^^^^^^^
    File "/home/mhartmay/storage/git/virtme-ng/virtme/commands/run.py", line 1198, in do_it
      kernel = find_kernel_and_mods(arch, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/mhartmay/storage/git/virtme-ng/virtme/commands/run.py", line 575, in find_kernel_and_mods
      kver = get_kernel_version(kimg, img_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/mhartmay/storage/git/virtme-ng/virtme/commands/run.py", line 520, in get_kernel_version
      match = re.search(rf"{img_name}-({version_pattern})", path)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/re/__init__.py", line 177, in search
      return _compile(pattern, flags).search(string)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: expected string or bytes-like object, got 'PosixPath'

Fixes: 2290a6a7e3c4 ("commands: run.py: Resolve symlinks on get_kernel_version")