### PR TITLE
virtme-init: Improve nested virtme-ng performance

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -214,7 +214,7 @@ if [[ -n $udevd ]]; then
         echo '' > /sys/kernel/uevent_helper
     fi
     log "starting udevd"
-    udev_out=$($udevd --daemon --resolve-names=never 2>&1)
+    udev_out=$($udevd --daemon 2>&1)
     if ! grep -q "quiet" /proc/cmdline; then
         log "udev: $udev_out"
     fi

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -586,7 +586,7 @@ fn run_udevd() -> Option<thread::JoinHandle<()>> {
     if let Some(udevd_path) = find_udevd() {
         let handle = thread::spawn(move || {
             disable_uevent_helper();
-            let args: &[&str] = &["--daemon", "--resolve-names=never"];
+            let args: &[&str] = &["--daemon"];
             utils::run_cmd(udevd_path, args);
             log!("triggering udev coldplug");
             utils::run_cmd("udevadm", &["trigger", "--type=subsystems", "--action=add"]);


### PR DESCRIPTION
Nested virtme-ng instances are very slow out of the box:

    host:linux$ ../virtme-ng/vng --build
    host:linux$ ../virtme-ng/vng

    [    0.019238] Booting paravirtualized kernel on KVM
    [    0.253527]     virtme_user=iii

    virtme-ng:linux$ ../virtme-ng/vng

    [    0.236793] Booting paravirtualized kernel on bare hardware
    [    7.396265]     virtme_user=iii

This is because they use TCG instead of KVM. This is, in turn, because /dev/kvm is not accessible due to having root:root ownership instead of root:kvm.

Setting the ownership is implemented in
/lib/udev/rules.d/50-udev-default.rules as follows:

    KERNEL=="kvm", GROUP="kvm", MODE="0660", OPTIONS+="static_node=kvm"

virtme-ng starts udev with the --resolve-names=never option, which makes it ignore the GROUP= assignment [1].

It's not really clear why specifying this option is necessary, but virtme-ng used it from the very beginning. Perhaps in some situations /etc/passwd and /etc/group are not mounted in a timely fashion. So, instead of dropping it, replace "never" with "late".

[1] https://github.com/systemd/systemd/blob/v258/src/udev/udev-rules.c#L1087