### PR TITLE
virtme-init: Increase timeout for udevadm settle

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -222,7 +222,7 @@ if [[ -n $udevd ]]; then
     udevadm trigger --type=subsystems --action=add > /dev/null 2>&1
     udevadm trigger --type=devices --action=add > /dev/null 2>&1
     log "waiting for udev to settle"
-    udevadm settle
+    udevadm settle --timeout=300
     log "udev is done"
 else
     log "udevd not found"

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -592,7 +592,7 @@ fn run_udevd() -> Option<thread::JoinHandle<()>> {
             utils::run_cmd("udevadm", &["trigger", "--type=subsystems", "--action=add"]);
             utils::run_cmd("udevadm", &["trigger", "--type=devices", "--action=add"]);
             log!("waiting for udev to settle");
-            utils::run_cmd("udevadm", &["settle"]);
+            utils::run_cmd("udevadm", &["settle", "--timeout=300"]);
             log!("udev is done");
         });
         Some(handle)


### PR DESCRIPTION
By default, udevadm has a 2 minutes timeout:
https://github.com/systemd/systemd/blob/main/src/udev/udevadm-settle.c#L27

This is more than enough for a normal system, but when running inside a virtual machine without kvm this timeout might not be enough.

Media-ci has seen a spike of this errors:

```
[  174.273649] virtme-init: waiting for udev to settle
Failed to wait for daemon to reply: Connection timed out
[  296.460652] virtme-init: udev is done
[  300.023643] ip (123) used greatest stack depth: 11808 bytes left
touch: cannot touch '/etc/sudoers': Read-only file system
touch: cannot touch '/etc/sudoers': Read-only file system
mount: /etc/sudoers: mount point does not exist.
       dmesg(1) may have more information after failed mount system call.
virtme-init: cannot find script I/O ports; make sure virtio-serial is available
```
https://gitlab.freedesktop.org/linux-media/users/ci/-/jobs/85882743

When it works, it requires around 100+ seconds to settle:

```
[  124.949429] virtme-init: waiting for udev to settle
[  227.774217] udevadm (136) used greatest stack depth: 11680 bytes left
[  227.787152] virtme-init: udev is done
```

In theory we could even have `--timeout=infinity`, but that could break other usecases.