### PR TITLE
virtme-init: Fix `base64: invalid input`

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -307,7 +307,7 @@ if [[ -n ${vsock_exec} ]]; then
         "EXEC:\"${vsock_exec}\",pty,stderr,setsid,sigint,sane,echo=0" &
 fi
 
-user_cmd=$(sed -ne "s/.*virtme.exec=\`\(.*\)\`.*/\1/p" /proc/cmdline)
+user_cmd=$(sed -ne "s/.*virtme.exec=\`\([^\`]*\)\`.*/\1/p" /proc/cmdline)
 if [[ -n ${user_cmd} ]]; then
     if [[ ! -e "/dev/virtio-ports/virtme.stdin" ||
         ! -e "/dev/virtio-ports/virtme.stdout" ||


### PR DESCRIPTION
When using both --exec and --console, there is an annoying `base64: invalid input` message, which does not lead to any failures.

The reason is that the user_cmd variable ends up being something like:

    <base64 stuff>` virtme.vsockexec=`/tmp/virtme-console/9000.sh

due to greedy regex matching.

Exclude the "`" character to prevent it from happening.