### PR TITLE
virtme: Support memoryless NUMA nodes

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1225,14 +1225,18 @@ def do_it() -> int:
         for i, numa in enumerate(args.numa, start=1):
             size, cpus = numa.split(",", 1) if "," in numa else (numa, None)
             cpus = f",{cpus}" if cpus else ""
-            qemuargs.extend(
-                [
+
+            if size == "0":
+                obj_args = []
+                numa_args = ["-numa", f"node{cpus}"]
+            else:
+                obj_args = [
                     "-object",
                     f"memory-backend-memfd,id=mem{i},size={size},share=on",
-                    "-numa",
-                    f"node,memdev=mem{i}{cpus}",
                 ]
-            )
+                numa_args = ["-numa", f"node,memdev=mem{i}{cpus}"]
+
+            qemuargs.extend(obj_args + numa_args)
 
     if args.numa_distance:
         for arg in args.numa_distance:


### PR DESCRIPTION
Allow specifying size=0 in the --numa argument to represent memoryless nodes. In this case, only a -numa node option is added to QEMU without creating a corresponding memory-backend object.

This enables simulating heterogeneous architectures where some NUMA nodes lack directly attached system memory, e.g., to represent device proximity, such as a GPU exposed as a memoryless node to model its locality to specific CPUs.

Example usage:
```
  $ vng --cpus 16 -m 2G --numa 2G,cpus=0-7 --numa 0,cpus=8-15 -- numactl -H
  available: 2 nodes (0-1)
  node 0 cpus: 0 1 2 3 4 5 6 7
  node 0 size: 1952 MB
  node 0 free: 1828 MB
  node 1 cpus: 8 9 10 11 12 13 14 15
  node 1 size: 0 MB
  node 1 free: 0 MB
  node distances:
  node     0    1
     0:   10   20
     1:   20   10
```
This closes #362.

Suggested-by: Vlastimil Babka <vbabka@suse.cz>
Suggested-by: David Hildenbrand <david@redhat.com>