### PR TITLE
virtme-init: Send guest's hostname to the DHCP server

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -272,7 +272,11 @@ if grep -q -E '(^| )virtme.dhcp($| )' /proc/cmdline; then
     # udev is liable to rename the interface out from under us.
     for d in /sys/bus/virtio/drivers/virtio_net/virtio*/net/*; do
         virtme_net=$(basename "${d}")
-        busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname -- "$0")/virtme-udhcpc-script" &
+        udhcpc_opts=(-i "$virtme_net" -n -q -f -s "$(dirname -- "$0")/virtme-udhcpc-script")
+        if [[ -n $virtme_hostname ]]; then
+            udhcpc_opts+=(-x hostname:"$virtme_hostname")
+        fi
+        busybox udhcpc "${udhcpc_opts[@]}" &
     done
     wait
 fi

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -656,7 +656,8 @@ fn get_network_handle(
     let network_dev_str = network_dev.unwrap();
     log!("setting up network device {}", network_dev_str);
     Some(thread::spawn(move || {
-        let args = [
+        let script = format!("{}/virtme-udhcpc-script", guest_tools_dir.unwrap());
+        let mut args = vec![
             "udhcpc",
             "-i",
             &network_dev_str,
@@ -664,8 +665,13 @@ fn get_network_handle(
             "-q",
             "-f",
             "-s",
-            &format!("{}/virtme-udhcpc-script", guest_tools_dir.unwrap()),
+            &script,
         ];
+        let hostname_opt_val;
+        if let Ok(hostname) = env::var("virtme_hostname") {
+            hostname_opt_val = format!("hostname:{}", hostname);
+            args.extend(["-x", &hostname_opt_val]);
+        }
         utils::run_cmd("busybox", &args);
     }))
 }


### PR DESCRIPTION
This way two virtme-ng guests, which use the same bridge, may locate each other by their hostnames. This is useful for creating multi-VM benchmarks.