### PR TITLE
   vng: Add `--empty-passwords` support

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -319,9 +319,13 @@ def make_parser() -> argparse.ArgumentParser:
         "--disable-monitor", action="store_true", help="Disable QEMU STDIO monitor"
     )
 
-    g = parser.add_argument_group(
-        title="Guest userspace configuration"
-    ).add_mutually_exclusive_group()
+    g = parser.add_argument_group(title="Guest userspace configuration")
+    g.add_argument(
+        "--empty-passwords",
+        action="store_true",
+        help="Set all user passwords to empty",
+    )
+    g = g.add_mutually_exclusive_group()
     g.add_argument(
         "--pwd",
         action="store_true",
@@ -1117,6 +1121,12 @@ def ssh_server(args, arch, qemuargs, kernelargs):
         )
         ssh_channel_type = "tcp"
 
+    if ssh_channel_type != "vsock" and args.empty_passwords:
+        arg_fail(
+            "--empty-passwords can only be used in combination with SSH over vsock",
+            show_usage=False,
+        )
+
     kernelargs.extend(
         [
             "virtme.ssh",
@@ -1452,6 +1462,9 @@ def do_it() -> int:
 
     for i, d in enumerate(args.overlay_rwdir):
         kernelargs.append(f"virtme_rw_overlay{i}={d}")
+
+    if args.empty_passwords:
+        kernelargs.append("virtme_empty_passwords=1")
 
     # Turn on KVM if available
     kvm_ok = can_use_kvm(args)

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -127,8 +127,14 @@ fi
 
 # Populate dummy entries in /etc/shadow to allow switching to any user defined
 # in the system
+# Lock the accounts by default
+value='!'
+
 (umask 0644 && touch /run/tmp/shadow)
-sed -e 's/^\([^:]\+\).*/\1:!:::::::/' < /etc/passwd > /run/tmp/shadow
+if (("${virtme_empty_passwords:-0}" == 1)); then
+    value=''
+fi
+sed -e "s/^\([^:]\+\).*/\1:${value}:::::::/" < /etc/passwd > /run/tmp/shadow
 mount --bind /run/tmp/shadow /etc/shadow
 
 # The /etc/lvm is usually only read/write by root. In order to allow commands like pvcreate to be

--- a/virtme/guest/virtme-sshd-script
+++ b/virtme/guest/virtme-sshd-script
@@ -87,10 +87,20 @@ if [[ ${virtme_ssh_channel} == "vsock" ]]; then
         echo "ssh: vsock module could not be loaded. SSHD cannot be started. Use '--ssh-tcp' instead to fallback to SSH over TCP." >&2
         exit 1
     fi
+
+    if (("${virtme_empty_passwords:-0}" == 1)); then
+        echo 'PermitEmptyPasswords yes' >> "${SSH_CONFIG}"
+    fi
+
     # 4294967295 == U32_MAX == -1
     declare -r VMADDR_CID_ANY=4294967295
     # TODO Use something like syslog or journal for the logging
     setsid --fork -- systemd-socket-activate --accept --listen="vsock:${VMADDR_CID_ANY}:22" --inetd -- /usr/sbin/sshd -i "${ARGS[@]}" &> /dev/null < /dev/null
 else
+    if (("${virtme_empty_passwords:-0}" == 1)); then
+        echo "Using TCP-based SSH together with empty passwords is insecure." >&2
+        exit 1
+    fi
+
     /usr/sbin/sshd "${ARGS[@]}"
 fi

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -185,6 +185,12 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     parser.add_argument(
+        "--empty-passwords",
+        action="store_true",
+        help="Use empty passwords for all users",
+    )
+
+    parser.add_argument(
         "--pin",
         "-P",
         nargs="?",
@@ -1303,6 +1309,11 @@ class KernelSource:
         else:
             self.virtme_param["busybox"] = ""
 
+    def _get_virtme_empty_passwords(self, args):
+        self.virtme_param["empty_passwords"] = ""
+        if args.empty_passwords:
+            self.virtme_param["empty_passwords"] = "--empty-passwords"
+
     def _get_virtme_qemu(self, args):
         if args.qemu is not None:
             self.virtme_param["qemu"] = "--qemu-bin " + args.qemu
@@ -1378,6 +1389,7 @@ class KernelSource:
         self._get_virtme_balloon(args)
         self._get_virtme_gdb(args)
         self._get_virtme_snaps(args)
+        self._get_virtme_empty_passwords(args)
         self._get_virtme_busybox(args)
         self._get_virtme_nvgpu(args)
         self._get_virtme_qemu(args)
@@ -1397,6 +1409,7 @@ class KernelSource:
             + f"{self.virtme_param['rwdir']} "
             + f"{self.virtme_param['overlay_rwdir']} "
             + f"{self.virtme_param['cwd']} "
+            + f"{self.virtme_param['empty_passwords']} "
             + f"{self.virtme_param['kdir']} "
             + f"{self.virtme_param['dry_run']} "
             + f"{self.virtme_param['no_virtme_ng_init']} "

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -305,9 +305,12 @@ fn generate_shadow() -> io::Result<()> {
     let reader = BufReader::new(input_file);
     let mut writer = BufWriter::new(output_file);
 
+    let empty_passwords = env::var("virtme_empty_passwords").unwrap_or(0.to_string());
+    let value = if empty_passwords == "1" { "" } else { "!" };
+
     for line in reader.lines() {
         if let Some((username, _)) = line?.split_once(':') {
-            writeln!(writer, "{username}:!:::::::")?;
+            writeln!(writer, "{username}:{value}:::::::")?;
         }
     }
     utils::do_mount(


### PR DESCRIPTION
Add a `--empty-passwords` flag that sets all user passwords to empty.
    This is useful for simplifying debugging and enabling easier SSH access,
    e.g. if no SSH public key is available. In case of TCP-based SSH reject
    that with the following error message out of security reasons:

      $ vng -r --empty-passwords --ssh --ssh-tcp
      --empty-passwords can only be used in combination with SSH over vsock