### PR TITLE
Improve `vng-mcp` integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "virtme-ng"
 dynamic = ["version", "license", "authors", "dependencies", "readme", "description", "classifiers", "scripts"]
 requires-python = ">=3.10"
 
+[project.optional-dependencies]
+mcp = ["mcp>=0.9.0", "anyio>=4.0.0"]
+
 [build-system]
 requires = [
   "argparse-manpage[setuptools]",

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
         "console_scripts": [
             "vng = virtme_ng.run:main",
             "virtme-ng = virtme_ng.run:main",
-            "vng-mcp = virtme_ng.mcp:main",
+            "vng-mcp = virtme_ng.mcp:main [mcp]",
             "virtme-run = virtme.commands.run:main",
             "virtme-configkernel = virtme.commands.configkernel:main",
             "virtme-mkinitramfs = virtme.commands.mkinitramfs:main",


### PR DESCRIPTION
With this change it's possible to install `virtme-ng` with the extra requirements for MCP. See [1] for details.

 $ cd virtme-ng
 $ pipx install '.[mcp]'

Before:
  $ vng --mcp
  Error: mcp package not found. Install it with: pip install mcp

After:
  $ vng --mcp

[1] https://setuptools.pypa.io/en/latest/userguide/dependency_management.html