### PR TITLE
virtme-ng: setup: Remove vng-mcp from scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,6 @@ setup(
     package_data={"virtme.guest": package_files},
     data_files=data_files,
     scripts=[
-        "vng-mcp",
         "bin/virtme-prep-kdir-mods",
         "bin/virtme-ssh-proxy",
     ],


### PR DESCRIPTION
vng-mpc has been incorrectly added to the 'scripts' list, which is unnecessary since it's also provided as a regular command via entry_points.

Remove it to prevent potential conflicts when building the package.

This should address issue #384.