### PR TITLE
Add support for `vng --blk-disk` and appending disk I/O / topology options to either `--*disk`

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import termios
 from base64 import b64encode
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
@@ -38,6 +39,7 @@ from virtme_ng.utils import (
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
     get_conf,
     scsi_device_id,
+    strtobool,
 )
 
 from .. import architectures, mkinitramfs, modfinder, qemu_helpers, resources, virtmods
@@ -206,15 +208,21 @@ def make_parser() -> argparse.ArgumentParser:
         "--scsi-disk",
         action="append",
         default=[],
-        metavar="NAME=PATH",
-        help="Add a read/write virtio-scsi disk.  The device node will be /dev/disk/by-id/scsi-0virtme_disk_NAME.",
+        metavar="NAME=PATH[,OPT...]",
+        help="Add a read/write virtio-scsi disk, available at "
+        + "/dev/disk/by-id/scsi-0virtme_disk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
     g.add_argument(
         "--blk-disk",
         action="append",
         default=[],
-        metavar="NAME=PATH",
-        help="Add a read/write virtio-blk disk.  The device nodes will be /dev/disk/by-id/virtio-virtme_disk_blk_NAME.",
+        metavar="NAME=PATH[,OPT...]",
+        help="Add a read/write virtio-blk disk, available at "
+        + "/dev/disk/by-id/virtio-virtme_disk_blk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
     g.add_argument(
         "--memory",
@@ -972,11 +980,127 @@ def create_guest_init_script(root: str, initsh: str) -> str | None:
 class DiskArg:
     name: str
     path: str
+    opts: dict[str, str]
+
+    _OPTS_HELP = {
+        # meta parameters
+        "topology": ("bool", "Forward host device topology (sector and I/O sizes)"),
+        "iothread": ("bool", "Create a dedicated I/O thread for the disk"),
+        # general format parameters
+        "format": ("str", "Disk image format (raw|qcow2)"),
+        # I/O driver parameters
+        "cache": ("str", "Cache mode (none|writeback|writethrough|directsync|unsafe)"),
+        "aio": ("str", "Asynchronous I/O mode (native|threads|io_uring)"),
+        "discard": (
+            "bool",
+            "Pass through TRIM/UNMAP requests (true=unmap, false=ignore)",
+        ),
+        "detect-zeroes": ("bool", "Detect all-zero writes (true=on/unmap, false=off)"),
+        "queues": ("int", "Number of I/O queues"),
+        # topology parameters
+        # "alignment": ("bytes", "Block alignment offset"),
+        "log-sec": ("bytes", "Logical (LBA) sector size (typically 512 or 4096)"),
+        "phy-sec": ("bytes", "Physical (underlying) sector size (>=log-sec)"),
+        "min-io": ("bytes", "Minimum I/O request size"),
+        "opt-io": ("bytes", "Optimal I/O request size"),
+        "rota": ("bool", "Device is rotational"),
+        # "wzeroes": ("bytes", "Maximum WRITE ZEROES request size"),
+        # "disc-aln": ("bytes", "TRIM/UNMAP alignment offset"),
+        "disc-gran": ("bytes", "TRIM/UNMAP request granularity"),
+        # "disc-max": ("bytes", "Maximum TRIM/UNMAP request size"),
+        # "disc-zero": ("bool", "TRIM/UNMAP zeroes data"),
+    }
+
+    def __post_init__(self):
+        if self.pop_opt("topology", strtobool, False):
+            self.opts = self.topology() | self.opts
+
+    def get_opt(
+        self, name: str, parser: Callable[[str], Any] = str, default: Any = None
+    ) -> Any:
+        opt = self.opts.get(name, None)
+        return parser(opt) if opt is not None else default
+
+    def pop_opt(
+        self, name: str, parser: Callable[[str], Any] = str, default: Any = None
+    ) -> Any:
+        opt = self.opts.pop(name, None)
+        return parser(opt) if opt is not None else default
+
+    def pop_opt_qemu(
+        self,
+        name: str,
+        default: Any = None,
+        *,
+        parser: Callable[[str], Any] = str,
+        dest: str | None = None,
+    ) -> str | None:
+        opt = self.pop_opt(name, parser, default)
+        # return DiskArg.qemu_opt(name=qemu if qemu is not None else name, value=opt)
+        if opt is None:
+            return None
+        if isinstance(opt, bool):
+            opt = "on" if opt else "off"
+        return f"{dest if dest is not None else name}={opt}"
+
+    def topology(self) -> dict[str, str]:
+        # Get the real device name (handles symlinks like /dev/mapper -> /dev/dm-X)
+        real_path = os.path.realpath(self.path, strict=True)
+        dev_name = os.path.basename(real_path)
+        sys_base = Path(f"/sys/block/{dev_name}")
+
+        attributes = {
+            # 'alignment': ('alignment_offset', int),
+            "log-sec": ("queue/logical_block_size", int),
+            "phy-sec": ("queue/physical_block_size", int),
+            "min-io": ("queue/minimum_io_size", int),
+            "opt-io": ("queue/optimal_io_size", int),
+            "rota": ("queue/rotational", bool),
+            # 'wzeroes': ('queue/write_zeroes_max_bytes', int),
+            # 'disc-aln': ('discard_alignment', int),
+            "disc-gran": ("queue/discard_granularity", int),
+            # 'disc-max': ('queue/discard_max_bytes', int),
+            # 'disc-zero': ('queue/discard_zeroes_data', bool),
+        }
+
+        result = {}
+        for key, (path, parser) in attributes.items():
+            try:
+                value = sys_base.joinpath(path).read_text(encoding="ascii").strip()
+                if parser is int:
+                    parsed = parser(value)
+                    if parsed <= 0:
+                        continue
+                result[key] = value
+            except FileNotFoundError:
+                pass
+            except ValueError:
+                pass
+        return result
 
     # Validate name=path arguments to --scsi-disk and --blk-disk
     @classmethod
     def parse(cls, func: str, arg: str) -> "DiskArg":
-        name, sep, fn = arg.partition("=")
+        items = arg.split(",")
+
+        if "help" in items:
+            print(
+                "\n".join(
+                    [
+                        f"Possible {func} options:",
+                    ]
+                    + [
+                        "{:<20} {}".format(f"{key}=({typ})", value)
+                        for key, (typ, value) in DiskArg._OPTS_HELP.items()
+                    ]
+                )
+            )
+            sys.exit(0)
+
+        namefile = items[0]
+        extra = items[1:]
+
+        name, sep, fn = namefile.partition("=")
         if not (name and sep and fn):
             arg_fail(f"invalid argument to {func}: {arg}")
         if "=" in fn or "," in fn:
@@ -984,9 +1108,20 @@ class DiskArg:
         if "=" in name or "," in name:
             arg_fail(f"{func} device names cannot contain '=' or ',': {name}")
 
+        opts = {}
+        for i in extra:
+            key, sep, value = i.partition("=")
+            if not key:
+                arg_fail(f"invalid argument to {func}: {arg}")
+            if sep:
+                opts[key] = value
+            else:
+                opts[key] = "1"
+
         return cls(
             name=name,
             path=fn,
+            opts=opts,
         )
 
 
@@ -1770,6 +1905,8 @@ def do_it() -> int:
     if args.cpus:
         qemuargs.extend(["-smp", args.cpus])
 
+    iothread_index = 0
+
     if args.blk_disk:
         for i, d in enumerate(args.blk_disk):
             driveid = f"blk-disk{i}"
@@ -1779,13 +1916,63 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
-                "format=raw",
             ]
             device_opts = [
                 arch.virtio_dev_type("blk"),
                 f"drive={driveid}",
                 f"serial={disk.name}",
             ]
+
+            # we need those parameters multiple times
+            discard = disk.pop_opt("discard", parser=strtobool, default=None)
+            detect_zeroes = disk.pop_opt(
+                "detect-zeroes", parser=strtobool, default=None
+            )
+            # we need this parameter both to transform other parameters and as itself later
+            # log_sec = disk.get_opt("log-sec", parser=int, default=512)
+
+            drive_opts.extend(
+                [
+                    disk.pop_opt_qemu("format", "raw"),
+                    disk.pop_opt_qemu("cache", None),
+                    disk.pop_opt_qemu("aio", None),
+                    f"discard={'unmap' if discard else 'ignore'}"
+                    if discard is not None
+                    else None,
+                    f"detect-zeroes={('unmap' if discard else 'on') if detect_zeroes else 'off'}"
+                    if detect_zeroes is not None
+                    else None,
+                ]
+            )
+
+            device_opts.extend(
+                [
+                    f"discard={'on' if discard else 'off'}"
+                    if discard is not None
+                    else None,
+                    disk.pop_opt_qemu("disc-gran", dest="discard_granularity"),
+                    disk.pop_opt_qemu("log-sec", dest="logical_block_size"),
+                    disk.pop_opt_qemu("phy-sec", dest="physical_block_size"),
+                    # disk.pop_qemu("disc-max", dest="max-discard-sectors", parser=lambda arg: int(arg) / log_sec),
+                    # disk.pop_qemu("wzeroes", dest="max-write-zeroes-sectors", parser=lambda arg: int(arg) / log_sec),
+                    disk.pop_opt_qemu("min-io", dest="min_io_size"),
+                    disk.pop_opt_qemu("opt-io", dest="opt_io_size"),
+                    disk.pop_opt_qemu("queues", dest="num-queues"),
+                ]
+            )
+            # unused
+            disk.opts.pop("rota", None)
+
+            if disk.pop_opt("iothread", bool, False):
+                iothreadid = f"iothread{iothread_index}"
+                iothread_index += 1
+                qemuargs.extend(
+                    [
+                        "-object",
+                        f"iothread,id={iothreadid}",
+                    ]
+                )
+                device_opts.append(f"iothread={iothreadid}")
 
             qemuargs.extend(
                 [
@@ -1796,11 +1983,16 @@ def do_it() -> int:
                 ]
             )
 
-    if args.scsi_disk:
-        qemuargs.extend(["-device", "{},id=scsi".format(arch.virtio_dev_type("scsi"))])
+            # any options that were not consumed are errors
+            if disk.opts:
+                raise ValueError(
+                    f"invalid --disk parameter: {d!r}\n(keys were not consumed: {disk.opts.keys()})"
+                )
 
+    if args.scsi_disk:
         for i, d in enumerate(args.scsi_disk):
-            driveid = f"disk{i}"
+            scsiid = f"scsi{i}"
+            driveid = f"scsi-disk{i}"
             disk = DiskArg.parse("--scsi-disk", d)
 
             # scsi-hd.device_id= is normally defaulted to scsi-hd.serial=,
@@ -1809,29 +2001,104 @@ def do_it() -> int:
             # scsi-hd.serial= itself must not be longer than 36 characters
             serial = scsi_device_id(disk.name, 36)
 
+            scsi_opts = [
+                arch.virtio_dev_type("scsi"),
+                f"id={scsiid}",
+            ]
             drive_opts = [
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
-                "format=raw",
             ]
             device_opts = [
                 "scsi-hd",
                 f"drive={driveid}",
+                f"bus={scsiid}.0",
                 "vendor=virtme",
                 "product=disk",
                 f"serial={serial}",
                 f"device_id={device_id}" if device_id != serial else None,
             ]
 
+            # we need those parameters multiple times
+            discard = disk.pop_opt("discard", parser=strtobool, default=None)
+            detect_zeroes = disk.pop_opt(
+                "detect-zeroes", parser=strtobool, default=None
+            )
+            # we need this parameter both to transform other parameters and as itself later
+            log_sec = disk.get_opt("log-sec")
+
+            drive_opts.extend(
+                [
+                    disk.pop_opt_qemu("format", "raw"),
+                    disk.pop_opt_qemu("cache", None),
+                    disk.pop_opt_qemu("aio", None),
+                    f"discard={'unmap' if discard else 'ignore'}"
+                    if discard is not None
+                    else None,
+                    f"detect-zeroes={('unmap' if discard else 'on') if detect_zeroes else 'off'}"
+                    if detect_zeroes is not None
+                    else None,
+                ]
+            )
+
+            scsi_opts.extend(
+                [
+                    disk.pop_opt_qemu("queues", dest="num-queues"),
+                ]
+            )
+
+            device_opts.extend(
+                [
+                    disk.pop_opt_qemu("disc-gran", dest="discard_granularity"),
+                    disk.pop_opt_qemu("log-sec", dest="logical_block_size"),
+                    # convenience: QEMU does not automatically adjust physical_block_size
+                    # to be not less than logical_block_size (it errors out instead), so we do it here
+                    disk.pop_opt_qemu(
+                        "phy-sec", dest="physical_block_size", default=log_sec
+                    ),
+                    # disk.pop_qemu("disc-max", dest="max_unmap_size"),
+                    # disk.pop_qemu("wzeroes", dest="???"),
+                    disk.pop_opt_qemu("min-io", dest="min_io_size"),
+                    disk.pop_opt_qemu("opt-io", dest="opt_io_size"),
+                    # sic: set rotation_rate to "1" for non-rotating disks ("1" is a special value
+                    # that means "non-rotating medium"), but set to "0" for rotating disks
+                    # ("0" means "rotation rate not reported").
+                    disk.pop_opt_qemu(
+                        "rota",
+                        dest="rotation_rate",
+                        parser=lambda arg: "0" if strtobool(arg) else "1",
+                    ),
+                ]
+            )
+
+            if disk.pop_opt("iothread", bool, False):
+                iothreadid = f"iothread{iothread_index}"
+                iothread_index += 1
+                qemuargs.extend(
+                    [
+                        "-object",
+                        f"iothread,id={iothreadid}",
+                    ]
+                )
+                scsi_opts.append(f"iothread={iothreadid}")
+
             qemuargs.extend(
                 [
                     "-drive",
                     ",".join(o for o in drive_opts if o is not None),
                     "-device",
+                    ",".join(o for o in scsi_opts if o is not None),
+                    "-device",
                     ",".join(o for o in device_opts if o is not None),
                 ]
             )
+
+            # any options that were not consumed are errors
+            if disk.opts:
+                raise ValueError(
+                    f"invalid --disk parameter: {d!r}\n(keys were not consumed: {disk.opts.keys()})"
+                )
 
     if args.gdb_server is not None:
         qemuargs.extend(["-gdb", f"tcp:localhost:{args.gdb_server}"])

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1779,6 +1779,7 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
+                "format=raw",
             ]
             device_opts = [
                 arch.virtio_dev_type("blk"),
@@ -1812,6 +1813,7 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
+                "format=raw",
             ]
             device_opts = [
                 "scsi-hd",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -192,8 +192,16 @@ def make_parser() -> argparse.ArgumentParser:
     g.add_argument(
         "--snaps", action="store_true", help="Allow to execute snaps inside virtme-ng"
     )
+    # legacy alias (`vng --disk` and `virtme-run --disk` behavior is historically inconsistent)
     g.add_argument(
         "--disk",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help=argparse.SUPPRESS,  # hidden from --help
+    )
+    g.add_argument(
+        "--scsi-disk",
         action="append",
         default=[],
         metavar="NAME=PATH",
@@ -1308,6 +1316,13 @@ _RWDIR_RE = re.compile(f"^({_SAFE_PATH_PATTERN})(?:=({_SAFE_PATH_PATTERN}))?$")
 def do_it() -> int:
     args = _ARGPARSER.parse_args()
 
+    if args.disk:
+        sys.stderr.write(
+            "warning: `--disk` is deprecated, use `--scsi-disk` instead.\n"
+        )
+        args.scsi_disk.extend(args.disk)
+        args.disk = []
+
     if args.client is not None:
         if args.server is not None:
             arg_fail("--client cannot be used with --server.")
@@ -1760,12 +1775,12 @@ def do_it() -> int:
                 ]
             )
 
-    if args.disk:
+    if args.scsi_disk:
         qemuargs.extend(["-device", "{},id=scsi".format(arch.virtio_dev_type("scsi"))])
 
-        for i, d in enumerate(args.disk):
+        for i, d in enumerate(args.scsi_disk):
             driveid = f"disk{i}"
-            name, fn = sanitize_disk_args("--disk", d)
+            name, fn = sanitize_disk_args("--scsi-disk", d)
             qemuargs.extend(
                 [
                     "-drive",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -37,6 +37,7 @@ from virtme_ng.utils import (
     VIRTME_SSH_DESTINATION_NAME,
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
     get_conf,
+    scsi_device_id,
 )
 
 from .. import architectures, mkinitramfs, modfinder, qemu_helpers, resources, virtmods
@@ -1801,6 +1802,12 @@ def do_it() -> int:
             driveid = f"disk{i}"
             disk = DiskArg.parse("--scsi-disk", d)
 
+            # scsi-hd.device_id= is normally defaulted to scsi-hd.serial=,
+            # but it must not be longer than 20 characters
+            device_id = scsi_device_id(disk.name, 20)
+            # scsi-hd.serial= itself must not be longer than 36 characters
+            serial = scsi_device_id(disk.name, 36)
+
             drive_opts = [
                 "if=none",
                 f"id={driveid}",
@@ -1811,7 +1818,8 @@ def do_it() -> int:
                 f"drive={driveid}",
                 "vendor=virtme",
                 "product=disk",
-                f"serial={disk.name}",
+                f"serial={serial}",
+                f"device_id={device_id}" if device_id != serial else None,
             ]
 
             qemuargs.extend(

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import termios
 from base64 import b64encode
+from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
 from time import sleep
@@ -966,18 +967,26 @@ def create_guest_init_script(root: str, initsh: str) -> str | None:
     return f"/{os.path.basename(script_host_path)}"
 
 
-# Validate name=path arguments from --disk and --blk-disk
-def sanitize_disk_args(func: str, arg: str) -> tuple[str, str]:
-    namefile = arg.split("=", 1)
-    if len(namefile) != 2:
-        arg_fail(f"invalid argument to {func}")
-    name, fn = namefile
-    if "=" in fn or "," in fn:
-        arg_fail(f"{func} filenames cannot contain '=' or ','")
-    if "=" in name or "," in name:
-        arg_fail(f"{func} device names cannot contain '=' or ','")
+@dataclass(kw_only=True)
+class DiskArg:
+    name: str
+    path: str
 
-    return name, fn
+    # Validate name=path arguments to --scsi-disk and --blk-disk
+    @classmethod
+    def parse(cls, func: str, arg: str) -> "DiskArg":
+        name, sep, fn = arg.partition("=")
+        if not (name and sep and fn):
+            arg_fail(f"invalid argument to {func}: {arg}")
+        if "=" in fn or "," in fn:
+            arg_fail(f"{func} filenames cannot contain '=' or ',': {fn}")
+        if "=" in name or "," in name:
+            arg_fail(f"{func} device names cannot contain '=' or ',': {name}")
+
+        return cls(
+            name=name,
+            path=fn,
+        )
 
 
 def can_access_file(path):
@@ -1763,15 +1772,25 @@ def do_it() -> int:
     if args.blk_disk:
         for i, d in enumerate(args.blk_disk):
             driveid = f"blk-disk{i}"
-            name, fn = sanitize_disk_args("--blk-disk", d)
+            disk = DiskArg.parse("--blk-disk", d)
+
+            drive_opts = [
+                "if=none",
+                f"id={driveid}",
+                f"file={disk.path}",
+            ]
+            device_opts = [
+                arch.virtio_dev_type("blk"),
+                f"drive={driveid}",
+                f"serial={disk.name}",
+            ]
+
             qemuargs.extend(
                 [
                     "-drive",
-                    f"if=none,id={driveid},file={fn}",
+                    ",".join(o for o in drive_opts if o is not None),
                     "-device",
-                    "{},drive={},serial={}".format(
-                        arch.virtio_dev_type("blk"), driveid, name
-                    ),
+                    ",".join(o for o in device_opts if o is not None),
                 ]
             )
 
@@ -1780,13 +1799,27 @@ def do_it() -> int:
 
         for i, d in enumerate(args.scsi_disk):
             driveid = f"disk{i}"
-            name, fn = sanitize_disk_args("--scsi-disk", d)
+            disk = DiskArg.parse("--scsi-disk", d)
+
+            drive_opts = [
+                "if=none",
+                f"id={driveid}",
+                f"file={disk.path}",
+            ]
+            device_opts = [
+                "scsi-hd",
+                f"drive={driveid}",
+                "vendor=virtme",
+                "product=disk",
+                f"serial={disk.name}",
+            ]
+
             qemuargs.extend(
                 [
                     "-drive",
-                    f"if=none,id={driveid},file={fn}",
+                    ",".join(o for o in drive_opts if o is not None),
                     "-device",
-                    f"scsi-hd,drive={driveid},vendor=virtme,product=disk,serial={name}",
+                    ",".join(o for o in device_opts if o is not None),
                 ]
             )
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -23,6 +23,7 @@ import tempfile
 import termios
 import threading
 from base64 import b64encode
+from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
 from time import sleep
@@ -1006,18 +1007,26 @@ def create_guest_init_script(root: str, initsh: str) -> str | None:
     return f"/{os.path.basename(script_host_path)}"
 
 
-# Validate name=path arguments from --disk and --blk-disk
-def sanitize_disk_args(func: str, arg: str) -> tuple[str, str]:
-    namefile = arg.split("=", 1)
-    if len(namefile) != 2:
-        arg_fail(f"invalid argument to {func}")
-    name, fn = namefile
-    if "=" in fn or "," in fn:
-        arg_fail(f"{func} filenames cannot contain '=' or ','")
-    if "=" in name or "," in name:
-        arg_fail(f"{func} device names cannot contain '=' or ','")
+@dataclass(kw_only=True)
+class DiskArg:
+    name: str
+    path: str
 
-    return name, fn
+    # Validate name=path arguments to --scsi-disk and --blk-disk
+    @classmethod
+    def parse(cls, func: str, arg: str) -> "DiskArg":
+        name, sep, fn = arg.partition("=")
+        if not (name and sep and fn):
+            arg_fail(f"invalid argument to {func}: {arg}")
+        if "=" in fn or "," in fn:
+            arg_fail(f"{func} filenames cannot contain '=' or ',': {fn}")
+        if "=" in name or "," in name:
+            arg_fail(f"{func} device names cannot contain '=' or ',': {name}")
+
+        return cls(
+            name=name,
+            path=fn,
+        )
 
 
 def can_access_file(path):
@@ -1805,15 +1814,25 @@ def do_it() -> int:
     if args.blk_disk:
         for i, d in enumerate(args.blk_disk):
             driveid = f"blk-disk{i}"
-            name, fn = sanitize_disk_args("--blk-disk", d)
+            disk = DiskArg.parse("--blk-disk", d)
+
+            drive_opts = [
+                "if=none",
+                f"id={driveid}",
+                f"file={disk.path}",
+            ]
+            device_opts = [
+                arch.virtio_dev_type("blk"),
+                f"drive={driveid}",
+                f"serial={disk.name}",
+            ]
+
             qemuargs.extend(
                 [
                     "-drive",
-                    f"if=none,id={driveid},file={fn}",
+                    ",".join(o for o in drive_opts if o is not None),
                     "-device",
-                    "{},drive={},serial={}".format(
-                        arch.virtio_dev_type("blk"), driveid, name
-                    ),
+                    ",".join(o for o in device_opts if o is not None),
                 ]
             )
 
@@ -1822,13 +1841,27 @@ def do_it() -> int:
 
         for i, d in enumerate(args.scsi_disk):
             driveid = f"disk{i}"
-            name, fn = sanitize_disk_args("--scsi-disk", d)
+            disk = DiskArg.parse("--scsi-disk", d)
+
+            drive_opts = [
+                "if=none",
+                f"id={driveid}",
+                f"file={disk.path}",
+            ]
+            device_opts = [
+                "scsi-hd",
+                f"drive={driveid}",
+                "vendor=virtme",
+                "product=disk",
+                f"serial={disk.name}",
+            ]
+
             qemuargs.extend(
                 [
                     "-drive",
-                    f"if=none,id={driveid},file={fn}",
+                    ",".join(o for o in drive_opts if o is not None),
                     "-device",
-                    f"scsi-hd,drive={driveid},vendor=virtme,product=disk,serial={name}",
+                    ",".join(o for o in device_opts if o is not None),
                 ]
             )
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -23,6 +23,7 @@ import tempfile
 import termios
 import threading
 from base64 import b64encode
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
@@ -41,6 +42,7 @@ from virtme_ng.utils import (
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
     get_conf,
     scsi_device_id,
+    strtobool,
 )
 
 from .. import architectures, mkinitramfs, modfinder, qemu_helpers, resources, virtmods
@@ -229,15 +231,21 @@ def make_parser() -> "VirtmeArgumentParser":
         "--scsi-disk",
         action="append",
         default=[],
-        metavar="NAME=PATH",
-        help="Add a read/write virtio-scsi disk.  The device node will be /dev/disk/by-id/scsi-0virtme_disk_NAME.",
+        metavar="NAME=PATH[,OPT...]",
+        help="Add a read/write virtio-scsi disk, available at "
+        + "/dev/disk/by-id/scsi-0virtme_disk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
     g.add_argument(
         "--blk-disk",
         action="append",
         default=[],
-        metavar="NAME=PATH",
-        help="Add a read/write virtio-blk disk.  The device nodes will be /dev/disk/by-id/virtio-virtme_disk_blk_NAME.",
+        metavar="NAME=PATH[,OPT...]",
+        help="Add a read/write virtio-blk disk, available at "
+        + "/dev/disk/by-id/virtio-virtme_disk_blk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
     g.add_argument(
         "--memory",
@@ -1012,11 +1020,127 @@ def create_guest_init_script(root: str, initsh: str) -> str | None:
 class DiskArg:
     name: str
     path: str
+    opts: dict[str, str]
+
+    _OPTS_HELP = {
+        # meta parameters
+        "topology": ("bool", "Forward host device topology (sector and I/O sizes)"),
+        "iothread": ("bool", "Create a dedicated I/O thread for the disk"),
+        # general format parameters
+        "format": ("str", "Disk image format (raw|qcow2)"),
+        # I/O driver parameters
+        "cache": ("str", "Cache mode (none|writeback|writethrough|directsync|unsafe)"),
+        "aio": ("str", "Asynchronous I/O mode (native|threads|io_uring)"),
+        "discard": (
+            "bool",
+            "Pass through TRIM/UNMAP requests (true=unmap, false=ignore)",
+        ),
+        "detect-zeroes": ("bool", "Detect all-zero writes (true=on/unmap, false=off)"),
+        "queues": ("int", "Number of I/O queues"),
+        # topology parameters
+        # "alignment": ("bytes", "Block alignment offset"),
+        "log-sec": ("bytes", "Logical (LBA) sector size (typically 512 or 4096)"),
+        "phy-sec": ("bytes", "Physical (underlying) sector size (>=log-sec)"),
+        "min-io": ("bytes", "Minimum I/O request size"),
+        "opt-io": ("bytes", "Optimal I/O request size"),
+        "rota": ("bool", "Device is rotational"),
+        # "wzeroes": ("bytes", "Maximum WRITE ZEROES request size"),
+        # "disc-aln": ("bytes", "TRIM/UNMAP alignment offset"),
+        "disc-gran": ("bytes", "TRIM/UNMAP request granularity"),
+        # "disc-max": ("bytes", "Maximum TRIM/UNMAP request size"),
+        # "disc-zero": ("bool", "TRIM/UNMAP zeroes data"),
+    }
+
+    def __post_init__(self):
+        if self.pop_opt("topology", strtobool, False):
+            self.opts = self.topology() | self.opts
+
+    def get_opt(
+        self, name: str, parser: Callable[[str], Any] = str, default: Any = None
+    ) -> Any:
+        opt = self.opts.get(name, None)
+        return parser(opt) if opt is not None else default
+
+    def pop_opt(
+        self, name: str, parser: Callable[[str], Any] = str, default: Any = None
+    ) -> Any:
+        opt = self.opts.pop(name, None)
+        return parser(opt) if opt is not None else default
+
+    def pop_opt_qemu(
+        self,
+        name: str,
+        default: Any = None,
+        *,
+        parser: Callable[[str], Any] = str,
+        dest: str | None = None,
+    ) -> str | None:
+        opt = self.pop_opt(name, parser, default)
+        # return DiskArg.qemu_opt(name=qemu if qemu is not None else name, value=opt)
+        if opt is None:
+            return None
+        if isinstance(opt, bool):
+            opt = "on" if opt else "off"
+        return f"{dest if dest is not None else name}={opt}"
+
+    def topology(self) -> dict[str, str]:
+        # Get the real device name (handles symlinks like /dev/mapper -> /dev/dm-X)
+        real_path = os.path.realpath(self.path, strict=True)
+        dev_name = os.path.basename(real_path)
+        sys_base = Path(f"/sys/block/{dev_name}")
+
+        attributes = {
+            # 'alignment': ('alignment_offset', int),
+            "log-sec": ("queue/logical_block_size", int),
+            "phy-sec": ("queue/physical_block_size", int),
+            "min-io": ("queue/minimum_io_size", int),
+            "opt-io": ("queue/optimal_io_size", int),
+            "rota": ("queue/rotational", bool),
+            # 'wzeroes': ('queue/write_zeroes_max_bytes', int),
+            # 'disc-aln': ('discard_alignment', int),
+            "disc-gran": ("queue/discard_granularity", int),
+            # 'disc-max': ('queue/discard_max_bytes', int),
+            # 'disc-zero': ('queue/discard_zeroes_data', bool),
+        }
+
+        result = {}
+        for key, (path, parser) in attributes.items():
+            try:
+                value = sys_base.joinpath(path).read_text(encoding="ascii").strip()
+                if parser is int:
+                    parsed = parser(value)
+                    if parsed <= 0:
+                        continue
+                result[key] = value
+            except FileNotFoundError:
+                pass
+            except ValueError:
+                pass
+        return result
 
     # Validate name=path arguments to --scsi-disk and --blk-disk
     @classmethod
     def parse(cls, func: str, arg: str) -> "DiskArg":
-        name, sep, fn = arg.partition("=")
+        items = arg.split(",")
+
+        if "help" in items:
+            print(
+                "\n".join(
+                    [
+                        f"Possible {func} options:",
+                    ]
+                    + [
+                        "{:<20} {}".format(f"{key}=({typ})", value)
+                        for key, (typ, value) in DiskArg._OPTS_HELP.items()
+                    ]
+                )
+            )
+            sys.exit(0)
+
+        namefile = items[0]
+        extra = items[1:]
+
+        name, sep, fn = namefile.partition("=")
         if not (name and sep and fn):
             arg_fail(f"invalid argument to {func}: {arg}")
         if "=" in fn or "," in fn:
@@ -1024,9 +1148,20 @@ class DiskArg:
         if "=" in name or "," in name:
             arg_fail(f"{func} device names cannot contain '=' or ',': {name}")
 
+        opts = {}
+        for i in extra:
+            key, sep, value = i.partition("=")
+            if not key:
+                arg_fail(f"invalid argument to {func}: {arg}")
+            if sep:
+                opts[key] = value
+            else:
+                opts[key] = "1"
+
         return cls(
             name=name,
             path=fn,
+            opts=opts,
         )
 
 
@@ -1812,6 +1947,8 @@ def do_it() -> int:
     if args.cpus:
         qemuargs.extend(["-smp", args.cpus])
 
+    iothread_index = 0
+
     if args.blk_disk:
         for i, d in enumerate(args.blk_disk):
             driveid = f"blk-disk{i}"
@@ -1821,13 +1958,63 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
-                "format=raw",
             ]
             device_opts = [
                 arch.virtio_dev_type("blk"),
                 f"drive={driveid}",
                 f"serial={disk.name}",
             ]
+
+            # we need those parameters multiple times
+            discard = disk.pop_opt("discard", parser=strtobool, default=None)
+            detect_zeroes = disk.pop_opt(
+                "detect-zeroes", parser=strtobool, default=None
+            )
+            # we need this parameter both to transform other parameters and as itself later
+            # log_sec = disk.get_opt("log-sec", parser=int, default=512)
+
+            drive_opts.extend(
+                [
+                    disk.pop_opt_qemu("format", "raw"),
+                    disk.pop_opt_qemu("cache", None),
+                    disk.pop_opt_qemu("aio", None),
+                    f"discard={'unmap' if discard else 'ignore'}"
+                    if discard is not None
+                    else None,
+                    f"detect-zeroes={('unmap' if discard else 'on') if detect_zeroes else 'off'}"
+                    if detect_zeroes is not None
+                    else None,
+                ]
+            )
+
+            device_opts.extend(
+                [
+                    f"discard={'on' if discard else 'off'}"
+                    if discard is not None
+                    else None,
+                    disk.pop_opt_qemu("disc-gran", dest="discard_granularity"),
+                    disk.pop_opt_qemu("log-sec", dest="logical_block_size"),
+                    disk.pop_opt_qemu("phy-sec", dest="physical_block_size"),
+                    # disk.pop_qemu("disc-max", dest="max-discard-sectors", parser=lambda arg: int(arg) / log_sec),
+                    # disk.pop_qemu("wzeroes", dest="max-write-zeroes-sectors", parser=lambda arg: int(arg) / log_sec),
+                    disk.pop_opt_qemu("min-io", dest="min_io_size"),
+                    disk.pop_opt_qemu("opt-io", dest="opt_io_size"),
+                    disk.pop_opt_qemu("queues", dest="num-queues"),
+                ]
+            )
+            # unused
+            disk.opts.pop("rota", None)
+
+            if disk.pop_opt("iothread", bool, False):
+                iothreadid = f"iothread{iothread_index}"
+                iothread_index += 1
+                qemuargs.extend(
+                    [
+                        "-object",
+                        f"iothread,id={iothreadid}",
+                    ]
+                )
+                device_opts.append(f"iothread={iothreadid}")
 
             qemuargs.extend(
                 [
@@ -1838,11 +2025,16 @@ def do_it() -> int:
                 ]
             )
 
-    if args.scsi_disk:
-        qemuargs.extend(["-device", "{},id=scsi".format(arch.virtio_dev_type("scsi"))])
+            # any options that were not consumed are errors
+            if disk.opts:
+                raise ValueError(
+                    f"invalid --disk parameter: {d!r}\n(keys were not consumed: {disk.opts.keys()})"
+                )
 
+    if args.scsi_disk:
         for i, d in enumerate(args.scsi_disk):
-            driveid = f"disk{i}"
+            scsiid = f"scsi{i}"
+            driveid = f"scsi-disk{i}"
             disk = DiskArg.parse("--scsi-disk", d)
 
             # scsi-hd.device_id= is normally defaulted to scsi-hd.serial=,
@@ -1851,29 +2043,104 @@ def do_it() -> int:
             # scsi-hd.serial= itself must not be longer than 36 characters
             serial = scsi_device_id(disk.name, 36)
 
+            scsi_opts = [
+                arch.virtio_dev_type("scsi"),
+                f"id={scsiid}",
+            ]
             drive_opts = [
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
-                "format=raw",
             ]
             device_opts = [
                 "scsi-hd",
                 f"drive={driveid}",
+                f"bus={scsiid}.0",
                 "vendor=virtme",
                 "product=disk",
                 f"serial={serial}",
                 f"device_id={device_id}" if device_id != serial else None,
             ]
 
+            # we need those parameters multiple times
+            discard = disk.pop_opt("discard", parser=strtobool, default=None)
+            detect_zeroes = disk.pop_opt(
+                "detect-zeroes", parser=strtobool, default=None
+            )
+            # we need this parameter both to transform other parameters and as itself later
+            log_sec = disk.get_opt("log-sec")
+
+            drive_opts.extend(
+                [
+                    disk.pop_opt_qemu("format", "raw"),
+                    disk.pop_opt_qemu("cache", None),
+                    disk.pop_opt_qemu("aio", None),
+                    f"discard={'unmap' if discard else 'ignore'}"
+                    if discard is not None
+                    else None,
+                    f"detect-zeroes={('unmap' if discard else 'on') if detect_zeroes else 'off'}"
+                    if detect_zeroes is not None
+                    else None,
+                ]
+            )
+
+            scsi_opts.extend(
+                [
+                    disk.pop_opt_qemu("queues", dest="num-queues"),
+                ]
+            )
+
+            device_opts.extend(
+                [
+                    disk.pop_opt_qemu("disc-gran", dest="discard_granularity"),
+                    disk.pop_opt_qemu("log-sec", dest="logical_block_size"),
+                    # convenience: QEMU does not automatically adjust physical_block_size
+                    # to be not less than logical_block_size (it errors out instead), so we do it here
+                    disk.pop_opt_qemu(
+                        "phy-sec", dest="physical_block_size", default=log_sec
+                    ),
+                    # disk.pop_qemu("disc-max", dest="max_unmap_size"),
+                    # disk.pop_qemu("wzeroes", dest="???"),
+                    disk.pop_opt_qemu("min-io", dest="min_io_size"),
+                    disk.pop_opt_qemu("opt-io", dest="opt_io_size"),
+                    # sic: set rotation_rate to "1" for non-rotating disks ("1" is a special value
+                    # that means "non-rotating medium"), but set to "0" for rotating disks
+                    # ("0" means "rotation rate not reported").
+                    disk.pop_opt_qemu(
+                        "rota",
+                        dest="rotation_rate",
+                        parser=lambda arg: "0" if strtobool(arg) else "1",
+                    ),
+                ]
+            )
+
+            if disk.pop_opt("iothread", bool, False):
+                iothreadid = f"iothread{iothread_index}"
+                iothread_index += 1
+                qemuargs.extend(
+                    [
+                        "-object",
+                        f"iothread,id={iothreadid}",
+                    ]
+                )
+                scsi_opts.append(f"iothread={iothreadid}")
+
             qemuargs.extend(
                 [
                     "-drive",
                     ",".join(o for o in drive_opts if o is not None),
                     "-device",
+                    ",".join(o for o in scsi_opts if o is not None),
+                    "-device",
                     ",".join(o for o in device_opts if o is not None),
                 ]
             )
+
+            # any options that were not consumed are errors
+            if disk.opts:
+                raise ValueError(
+                    f"invalid --disk parameter: {d!r}\n(keys were not consumed: {disk.opts.keys()})"
+                )
 
     if args.gdb_server is not None:
         qemuargs.extend(["-gdb", f"tcp:localhost:{args.gdb_server}"])

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1821,6 +1821,7 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
+                "format=raw",
             ]
             device_opts = [
                 arch.virtio_dev_type("blk"),
@@ -1854,6 +1855,7 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
+                "format=raw",
             ]
             device_opts = [
                 "scsi-hd",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -40,6 +40,7 @@ from virtme_ng.utils import (
     VIRTME_SSH_DESTINATION_NAME,
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
     get_conf,
+    scsi_device_id,
 )
 
 from .. import architectures, mkinitramfs, modfinder, qemu_helpers, resources, virtmods
@@ -1843,6 +1844,12 @@ def do_it() -> int:
             driveid = f"disk{i}"
             disk = DiskArg.parse("--scsi-disk", d)
 
+            # scsi-hd.device_id= is normally defaulted to scsi-hd.serial=,
+            # but it must not be longer than 20 characters
+            device_id = scsi_device_id(disk.name, 20)
+            # scsi-hd.serial= itself must not be longer than 36 characters
+            serial = scsi_device_id(disk.name, 36)
+
             drive_opts = [
                 "if=none",
                 f"id={driveid}",
@@ -1853,7 +1860,8 @@ def do_it() -> int:
                 f"drive={driveid}",
                 "vendor=virtme",
                 "product=disk",
-                f"serial={disk.name}",
+                f"serial={serial}",
+                f"device_id={device_id}" if device_id != serial else None,
             ]
 
             qemuargs.extend(

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -215,8 +215,16 @@ def make_parser() -> "VirtmeArgumentParser":
     g.add_argument(
         "--snaps", action="store_true", help="Allow to execute snaps inside virtme-ng"
     )
+    # legacy alias (`vng --disk` and `virtme-run --disk` behavior is historically inconsistent)
     g.add_argument(
         "--disk",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help=argparse.SUPPRESS,  # hidden from --help
+    )
+    g.add_argument(
+        "--scsi-disk",
         action="append",
         default=[],
         metavar="NAME=PATH",
@@ -1348,6 +1356,11 @@ _RWDIR_RE = re.compile(f"^({_SAFE_PATH_PATTERN})(?:=({_SAFE_PATH_PATTERN}))?$")
 def do_it() -> int:
     args = _ARGPARSER.parse_args()
 
+    if args.disk:
+        sys.stderr.write("warning: `--disk` is deprecated, use `--scsi-disk` instead.\n")
+        args.scsi_disk.extend(args.disk)
+        args.disk = []
+
     if args.client is not None:
         if args.server is not None:
             arg_fail("--client cannot be used with --server.")
@@ -1804,12 +1817,12 @@ def do_it() -> int:
                 ]
             )
 
-    if args.disk:
+    if args.scsi_disk:
         qemuargs.extend(["-device", "{},id=scsi".format(arch.virtio_dev_type("scsi"))])
 
-        for i, d in enumerate(args.disk):
+        for i, d in enumerate(args.scsi_disk):
             driveid = f"disk{i}"
-            name, fn = sanitize_disk_args("--disk", d)
+            name, fn = sanitize_disk_args("--scsi-disk", d)
             qemuargs.extend(
                 [
                     "-drive",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -23,6 +23,7 @@ import tempfile
 import termios
 import threading
 from base64 import b64encode
+from dataclasses import dataclass
 from pathlib import Path
 from shutil import copyfile, copytree, which
 from time import sleep
@@ -1128,18 +1129,26 @@ def create_guest_init_script(root: str, initsh: str) -> str | None:
     return f"/{os.path.basename(script_host_path)}"
 
 
-# Validate name=path arguments from --disk and --blk-disk
-def sanitize_disk_args(func: str, arg: str) -> tuple[str, str]:
-    namefile = arg.split("=", 1)
-    if len(namefile) != 2:
-        arg_fail(f"invalid argument to {func}")
-    name, fn = namefile
-    if "=" in fn or "," in fn:
-        arg_fail(f"{func} filenames cannot contain '=' or ','")
-    if "=" in name or "," in name:
-        arg_fail(f"{func} device names cannot contain '=' or ','")
+@dataclass(kw_only=True)
+class DiskArg:
+    name: str
+    path: str
 
-    return name, fn
+    # Validate name=path arguments to --scsi-disk and --blk-disk
+    @classmethod
+    def parse(cls, func: str, arg: str) -> "DiskArg":
+        name, sep, fn = arg.partition("=")
+        if not (name and sep and fn):
+            arg_fail(f"invalid {func} argument: {arg!r}")
+        if "=" in fn or "," in fn:
+            arg_fail(f"{func} filenames cannot contain '=' or ',': {fn}")
+        if "=" in name or "," in name:
+            arg_fail(f"{func} device names cannot contain '=' or ',': {name}")
+
+        return cls(
+            name=name,
+            path=fn,
+        )
 
 
 def can_access_file(path):
@@ -2031,15 +2040,25 @@ def do_it() -> int:
     if args.blk_disk:
         for i, d in enumerate(args.blk_disk):
             driveid = f"blk-disk{i}"
-            name, fn = sanitize_disk_args("--blk-disk", d)
+            disk = DiskArg.parse("--blk-disk", d)
+
+            drive_opts = [
+                "if=none",
+                f"id={driveid}",
+                f"file={disk.path}",
+            ]
+            device_opts = [
+                arch.virtio_dev_type("blk"),
+                f"drive={driveid}",
+                f"serial={disk.name}",
+            ]
+
             qemuargs.extend(
                 [
                     "-drive",
-                    f"if=none,id={driveid},file={fn}",
+                    ",".join(o for o in drive_opts if o is not None),
                     "-device",
-                    "{},drive={},serial={}".format(
-                        arch.virtio_dev_type("blk"), driveid, name
-                    ),
+                    ",".join(o for o in device_opts if o is not None),
                 ]
             )
 
@@ -2048,13 +2067,27 @@ def do_it() -> int:
 
         for i, d in enumerate(args.scsi_disk):
             driveid = f"disk{i}"
-            name, fn = sanitize_disk_args("--scsi-disk", d)
+            disk = DiskArg.parse("--scsi-disk", d)
+
+            drive_opts = [
+                "if=none",
+                f"id={driveid}",
+                f"file={disk.path}",
+            ]
+            device_opts = [
+                "scsi-hd",
+                f"drive={driveid}",
+                "vendor=virtme",
+                "product=disk",
+                f"serial={disk.name}",
+            ]
+
             qemuargs.extend(
                 [
                     "-drive",
-                    f"if=none,id={driveid},file={fn}",
+                    ",".join(o for o in drive_opts if o is not None),
                     "-device",
-                    f"scsi-hd,drive={driveid},vendor=virtme,product=disk,serial={name}",
+                    ",".join(o for o in device_opts if o is not None),
                 ]
             )
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -230,8 +230,16 @@ def make_parser() -> "VirtmeArgumentParser":
     g.add_argument(
         "--snaps", action="store_true", help="Allow to execute snaps inside virtme-ng"
     )
+    # legacy alias (`vng --disk` and `virtme-run --disk` behavior is historically inconsistent)
     g.add_argument(
         "--disk",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help=argparse.SUPPRESS,  # hidden from --help
+    )
+    g.add_argument(
+        "--scsi-disk",
         action="append",
         default=[],
         metavar="NAME=PATH",
@@ -1501,6 +1509,13 @@ _RWDIR_RE = re.compile(f"^({_SAFE_PATH_PATTERN})(?:=({_SAFE_PATH_PATTERN}))?$")
 def do_it() -> int:
     args = _ARGPARSER.parse_args()
 
+    if args.disk:
+        sys.stderr.write(
+            "warning: `--disk` is deprecated, use `--scsi-disk` instead.\n"
+        )
+        args.scsi_disk.extend(args.disk)
+        args.disk = []
+
     if args.client is not None:
         if args.server is not None:
             arg_fail("--client cannot be used with --server.")
@@ -2028,12 +2043,12 @@ def do_it() -> int:
                 ]
             )
 
-    if args.disk:
+    if args.scsi_disk:
         qemuargs.extend(["-device", "{},id=scsi".format(arch.virtio_dev_type("scsi"))])
 
-        for i, d in enumerate(args.disk):
+        for i, d in enumerate(args.scsi_disk):
             driveid = f"disk{i}"
-            name, fn = sanitize_disk_args("--disk", d)
+            name, fn = sanitize_disk_args("--scsi-disk", d)
             qemuargs.extend(
                 [
                     "-drive",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -23,6 +23,7 @@ import tempfile
 import termios
 import threading
 from base64 import b64encode
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import copyfile, copytree, which
@@ -40,6 +41,7 @@ from virtme_ng.utils import (
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
     get_conf,
     scsi_device_id,
+    strtobool,
 )
 
 from .. import (
@@ -244,15 +246,21 @@ def make_parser() -> "VirtmeArgumentParser":
         "--scsi-disk",
         action="append",
         default=[],
-        metavar="NAME=PATH",
-        help="Add a read/write virtio-scsi disk.  The device node will be /dev/disk/by-id/scsi-0virtme_disk_NAME.",
+        metavar="NAME=PATH[,OPT...]",
+        help="Add a read/write virtio-scsi disk, available at "
+        + "/dev/disk/by-id/scsi-0virtme_disk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
     g.add_argument(
         "--blk-disk",
         action="append",
         default=[],
-        metavar="NAME=PATH",
-        help="Add a read/write virtio-blk disk.  The device nodes will be /dev/disk/by-id/virtio-virtme_disk_blk_NAME.",
+        metavar="NAME=PATH[,OPT...]",
+        help="Add a read/write virtio-blk disk, available at "
+        + "/dev/disk/by-id/virtio-virtme_disk_blk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
     g.add_argument(
         "--memory",
@@ -1134,11 +1142,133 @@ def create_guest_init_script(root: str, initsh: str) -> str | None:
 class DiskArg:
     name: str
     path: str
+    opts: dict[str, str]
+    _func: str
+
+    _OPTS_HELP = {
+        # meta parameters
+        "topology": ("bool", "Forward host device topology (sector and I/O sizes)"),
+        "iothread": ("bool", "Create a dedicated I/O thread for the disk"),
+        # general format parameters
+        "format": ("str", "Disk image format (raw|qcow2)"),
+        # I/O driver parameters
+        "cache": ("str", "Cache mode (none|writeback|writethrough|directsync|unsafe)"),
+        "aio": ("str", "Asynchronous I/O mode (native|threads|io_uring)"),
+        "discard": (
+            "bool",
+            "Pass through TRIM/UNMAP requests (true=unmap, false=ignore)",
+        ),
+        "detect-zeroes": ("bool", "Detect all-zero writes (true=on/unmap, false=off)"),
+        "queues": ("int", "Number of I/O queues"),
+        # topology parameters
+        # "alignment": ("bytes", "Block alignment offset"),
+        "log-sec": ("bytes", "Logical (LBA) sector size (typically 512 or 4096)"),
+        "phy-sec": ("bytes", "Physical (underlying) sector size (>=log-sec)"),
+        "min-io": ("bytes", "Minimum I/O request size"),
+        "opt-io": ("bytes", "Optimal I/O request size"),
+        "rota": ("bool", "Device is rotational"),
+        # "wzeroes": ("bytes", "Maximum WRITE ZEROES request size"),
+        # "disc-aln": ("bytes", "TRIM/UNMAP alignment offset"),
+        "disc-gran": ("bytes", "TRIM/UNMAP request granularity"),
+        # "disc-max": ("bytes", "Maximum TRIM/UNMAP request size"),
+        # "disc-zero": ("bool", "TRIM/UNMAP zeroes data"),
+    }
+
+    def __post_init__(self):
+        if self.pop_opt("topology", strtobool, False):
+            self.opts = self.topology() | self.opts
+
+    def get_opt(
+        self, name: str, parser: Callable[[str], Any] = str, default: Any = None
+    ) -> Any:
+        opt = self.opts.get(name, None)
+        return parser(opt) if opt is not None else default
+
+    def pop_opt(
+        self, name: str, parser: Callable[[str], Any] = str, default: Any = None
+    ) -> Any:
+        opt = self.opts.pop(name, None)
+        return parser(opt) if opt is not None else default
+
+    def pop_opt_qemu(
+        self,
+        name: str,
+        default: Any = None,
+        *,
+        parser: Callable[[str], Any] = str,
+        dest: str | None = None,
+    ) -> str | None:
+        opt = self.pop_opt(name, parser, default)
+        # return DiskArg.qemu_opt(name=qemu if qemu is not None else name, value=opt)
+        if opt is None:
+            return None
+        if isinstance(opt, bool):
+            opt = "on" if opt else "off"
+        return f"{dest if dest is not None else name}={opt}"
+
+    def topology(self) -> dict[str, str]:
+        # Get the real device name (handles symlinks like /dev/mapper -> /dev/dm-X)
+        try:
+            real_path = os.path.realpath(self.path, strict=True)
+        except FileNotFoundError:
+            arg_fail(
+                f"disk path to {self._func} does not exist, cannot query topology: {self.path!r}"
+            )
+        dev_name = os.path.basename(real_path)
+        sys_base = Path(f"/sys/block/{dev_name}")
+
+        attributes = {
+            # 'alignment': ('alignment_offset', int),
+            "log-sec": ("queue/logical_block_size", int),
+            "phy-sec": ("queue/physical_block_size", int),
+            "min-io": ("queue/minimum_io_size", int),
+            "opt-io": ("queue/optimal_io_size", int),
+            "rota": ("queue/rotational", bool),
+            # 'wzeroes': ('queue/write_zeroes_max_bytes', int),
+            # 'disc-aln': ('discard_alignment', int),
+            "disc-gran": ("queue/discard_granularity", int),
+            # 'disc-max': ('queue/discard_max_bytes', int),
+            # 'disc-zero': ('queue/discard_zeroes_data', bool),
+        }
+
+        result = {}
+        for key, (path, parser) in attributes.items():
+            try:
+                value = sys_base.joinpath(path).read_text(encoding="ascii").strip()
+                if parser is int:
+                    parsed = parser(value)
+                    if parsed <= 0:
+                        continue
+                result[key] = value
+            except FileNotFoundError:
+                pass
+            except ValueError:
+                pass
+        return result
 
     # Validate name=path arguments to --scsi-disk and --blk-disk
     @classmethod
     def parse(cls, func: str, arg: str) -> "DiskArg":
-        name, sep, fn = arg.partition("=")
+        items = arg.split(",")
+
+        if "help" in items:
+            print(
+                "\n".join(
+                    [
+                        f"Possible {func} options:",
+                    ]
+                    + [
+                        "{:<20} {}".format(f"{key}=({typ})", value)
+                        for key, (typ, value) in DiskArg._OPTS_HELP.items()
+                    ]
+                )
+            )
+            sys.exit(0)
+
+        namefile = items[0]
+        extra = items[1:]
+
+        name, sep, fn = namefile.partition("=")
         if not (name and sep and fn):
             arg_fail(f"invalid {func} argument: {arg!r}")
         if "=" in fn or "," in fn:
@@ -1146,9 +1276,21 @@ class DiskArg:
         if "=" in name or "," in name:
             arg_fail(f"{func} device names cannot contain '=' or ',': {name}")
 
+        opts = {}
+        for i in extra:
+            key, sep, value = i.partition("=")
+            if not key:
+                arg_fail(f"invalid {func} argument: {arg!r}")
+            if sep:
+                opts[key] = value
+            else:
+                opts[key] = "1"
+
         return cls(
             name=name,
             path=fn,
+            opts=opts,
+            _func=func,
         )
 
 
@@ -2038,6 +2180,8 @@ def do_it() -> int:
     if args.cpus:
         qemuargs.extend(["-smp", args.cpus])
 
+    iothread_index = 0
+
     if args.blk_disk:
         for i, d in enumerate(args.blk_disk):
             driveid = f"blk-disk{i}"
@@ -2047,13 +2191,63 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
-                "format=raw",
             ]
             device_opts = [
                 arch.virtio_dev_type("blk"),
                 f"drive={driveid}",
                 f"serial={disk.name}",
             ]
+
+            # we need those parameters multiple times
+            discard = disk.pop_opt("discard", parser=strtobool, default=None)
+            detect_zeroes = disk.pop_opt(
+                "detect-zeroes", parser=strtobool, default=None
+            )
+            # we need this parameter both to transform other parameters and as itself later
+            # log_sec = disk.get_opt("log-sec", parser=int, default=512)
+
+            drive_opts.extend(
+                [
+                    disk.pop_opt_qemu("format", "raw"),
+                    disk.pop_opt_qemu("cache", None),
+                    disk.pop_opt_qemu("aio", None),
+                    f"discard={'unmap' if discard else 'ignore'}"
+                    if discard is not None
+                    else None,
+                    f"detect-zeroes={('unmap' if discard else 'on') if detect_zeroes else 'off'}"
+                    if detect_zeroes is not None
+                    else None,
+                ]
+            )
+
+            device_opts.extend(
+                [
+                    f"discard={'on' if discard else 'off'}"
+                    if discard is not None
+                    else None,
+                    disk.pop_opt_qemu("disc-gran", dest="discard_granularity"),
+                    disk.pop_opt_qemu("log-sec", dest="logical_block_size"),
+                    disk.pop_opt_qemu("phy-sec", dest="physical_block_size"),
+                    # disk.pop_qemu("disc-max", dest="max-discard-sectors", parser=lambda arg: int(arg) / log_sec),
+                    # disk.pop_qemu("wzeroes", dest="max-write-zeroes-sectors", parser=lambda arg: int(arg) / log_sec),
+                    disk.pop_opt_qemu("min-io", dest="min_io_size"),
+                    disk.pop_opt_qemu("opt-io", dest="opt_io_size"),
+                    disk.pop_opt_qemu("queues", dest="num-queues"),
+                ]
+            )
+            # unused
+            disk.opts.pop("rota", None)
+
+            if disk.pop_opt("iothread", strtobool, False):
+                iothreadid = f"iothread{iothread_index}"
+                iothread_index += 1
+                qemuargs.extend(
+                    [
+                        "-object",
+                        f"iothread,id={iothreadid}",
+                    ]
+                )
+                device_opts.append(f"iothread={iothreadid}")
 
             qemuargs.extend(
                 [
@@ -2064,11 +2258,16 @@ def do_it() -> int:
                 ]
             )
 
-    if args.scsi_disk:
-        qemuargs.extend(["-device", "{},id=scsi".format(arch.virtio_dev_type("scsi"))])
+            # any options that were not consumed are errors
+            if disk.opts:
+                arg_fail(
+                    f"unrecognized --blk-disk options in {d!r}: {', '.join(sorted(disk.opts.keys()))}"
+                )
 
+    if args.scsi_disk:
         for i, d in enumerate(args.scsi_disk):
-            driveid = f"disk{i}"
+            scsiid = f"scsi{i}"
+            driveid = f"scsi-disk{i}"
             disk = DiskArg.parse("--scsi-disk", d)
 
             # scsi-hd.device_id= is normally defaulted to scsi-hd.serial=,
@@ -2077,29 +2276,104 @@ def do_it() -> int:
             # scsi-hd.serial= itself must not be longer than 36 characters
             serial = scsi_device_id(disk.name, 36)
 
+            scsi_opts = [
+                arch.virtio_dev_type("scsi"),
+                f"id={scsiid}",
+            ]
             drive_opts = [
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
-                "format=raw",
             ]
             device_opts = [
                 "scsi-hd",
                 f"drive={driveid}",
+                f"bus={scsiid}.0",
                 "vendor=virtme",
                 "product=disk",
                 f"serial={serial}",
                 f"device_id={device_id}" if device_id != serial else None,
             ]
 
+            # we need those parameters multiple times
+            discard = disk.pop_opt("discard", parser=strtobool, default=None)
+            detect_zeroes = disk.pop_opt(
+                "detect-zeroes", parser=strtobool, default=None
+            )
+            # we need this parameter both to transform other parameters and as itself later
+            log_sec = disk.get_opt("log-sec")
+
+            drive_opts.extend(
+                [
+                    disk.pop_opt_qemu("format", "raw"),
+                    disk.pop_opt_qemu("cache", None),
+                    disk.pop_opt_qemu("aio", None),
+                    f"discard={'unmap' if discard else 'ignore'}"
+                    if discard is not None
+                    else None,
+                    f"detect-zeroes={('unmap' if discard else 'on') if detect_zeroes else 'off'}"
+                    if detect_zeroes is not None
+                    else None,
+                ]
+            )
+
+            scsi_opts.extend(
+                [
+                    disk.pop_opt_qemu("queues", dest="num-queues"),
+                ]
+            )
+
+            device_opts.extend(
+                [
+                    disk.pop_opt_qemu("disc-gran", dest="discard_granularity"),
+                    disk.pop_opt_qemu("log-sec", dest="logical_block_size"),
+                    # convenience: QEMU does not automatically adjust physical_block_size
+                    # to be not less than logical_block_size (it errors out instead), so we do it here
+                    disk.pop_opt_qemu(
+                        "phy-sec", dest="physical_block_size", default=log_sec
+                    ),
+                    # disk.pop_qemu("disc-max", dest="max_unmap_size"),
+                    # disk.pop_qemu("wzeroes", dest="???"),
+                    disk.pop_opt_qemu("min-io", dest="min_io_size"),
+                    disk.pop_opt_qemu("opt-io", dest="opt_io_size"),
+                    # sic: set rotation_rate to "1" for non-rotating disks ("1" is a special value
+                    # that means "non-rotating medium"), but set to "0" for rotating disks
+                    # ("0" means "rotation rate not reported").
+                    disk.pop_opt_qemu(
+                        "rota",
+                        dest="rotation_rate",
+                        parser=lambda arg: "0" if strtobool(arg) else "1",
+                    ),
+                ]
+            )
+
+            if disk.pop_opt("iothread", strtobool, False):
+                iothreadid = f"iothread{iothread_index}"
+                iothread_index += 1
+                qemuargs.extend(
+                    [
+                        "-object",
+                        f"iothread,id={iothreadid}",
+                    ]
+                )
+                scsi_opts.append(f"iothread={iothreadid}")
+
             qemuargs.extend(
                 [
                     "-drive",
                     ",".join(o for o in drive_opts if o is not None),
                     "-device",
+                    ",".join(o for o in scsi_opts if o is not None),
+                    "-device",
                     ",".join(o for o in device_opts if o is not None),
                 ]
             )
+
+            # any options that were not consumed are errors
+            if disk.opts:
+                raise ValueError(
+                    f"unrecognized --scsi-disk options in {d!r}: {', '.join(sorted(disk.opts.keys()))}"
+                )
 
     if args.gdb_server is not None:
         qemuargs.extend(["-gdb", f"tcp:localhost:{args.gdb_server}"])

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -2047,6 +2047,7 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
+                "format=raw",
             ]
             device_opts = [
                 arch.virtio_dev_type("blk"),
@@ -2080,6 +2081,7 @@ def do_it() -> int:
                 "if=none",
                 f"id={driveid}",
                 f"file={disk.path}",
+                "format=raw",
             ]
             device_opts = [
                 "scsi-hd",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -39,6 +39,7 @@ from virtme_ng.utils import (
     VIRTME_SSH_DESTINATION_NAME,
     VIRTME_SSH_HOSTNAME_CID_SEPARATORS,
     get_conf,
+    scsi_device_id,
 )
 
 from .. import (
@@ -2069,6 +2070,12 @@ def do_it() -> int:
             driveid = f"disk{i}"
             disk = DiskArg.parse("--scsi-disk", d)
 
+            # scsi-hd.device_id= is normally defaulted to scsi-hd.serial=,
+            # but it must not be longer than 20 characters
+            device_id = scsi_device_id(disk.name, 20)
+            # scsi-hd.serial= itself must not be longer than 36 characters
+            serial = scsi_device_id(disk.name, 36)
+
             drive_opts = [
                 "if=none",
                 f"id={driveid}",
@@ -2079,7 +2086,8 @@ def do_it() -> int:
                 f"drive={driveid}",
                 "vendor=virtme",
                 "product=disk",
-                f"serial={disk.name}",
+                f"serial={serial}",
+                f"device_id={device_id}" if device_id != serial else None,
             ]
 
             qemuargs.extend(

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1184,13 +1184,20 @@ class KernelSource:
             self.virtme_param["remote_cmd"] = ""
 
     def _get_virtme_disk(self, args):
+        def ensure_name(dsk: str) -> str:
+            if "=" not in dsk:
+                return f"{dsk}={dsk}"
+            return dsk
+
         disk_str = ""
         if args.scsi_disk is not None:
             for dsk in args.scsi_disk:
-                disk_str += f"--scsi-disk {dsk}={dsk} "
+                dsk = ensure_name(dsk)
+                disk_str += f"--scsi-disk {shlex.quote(dsk)} "
         if args.blk_disk is not None:
             for dsk in args.blk_disk:
-                disk_str += f"--blk-disk {dsk}={dsk} "
+                dsk = ensure_name(dsk)
+                disk_str += f"--blk-disk {shlex.quote(dsk)} "
         self.virtme_param["disk"] = disk_str
 
     def _get_virtme_sound(self, args):

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -407,12 +407,28 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         + "The last octet will be incremented for the next network devices.",
     )
 
+    # legacy alias (`vng --disk` and `virtme-run --disk` behavior is historically inconsistent)
     parser.add_argument(
         "--disk",
-        "-D",
+        # "-D",  # explicitly moved to `--blk-disk` to preserve behavior
+        action="append",
+        metavar="PATH",
+        help=argparse.SUPPRESS,
+    )
+
+    parser.add_argument(
+        "--scsi-disk",
         action="append",
         metavar="PATH",
         help="Add a file as virtio-scsi disk (can be used multiple times)",
+    )
+
+    parser.add_argument(
+        "--blk-disk",
+        "-D",
+        action="append",
+        metavar="PATH",
+        help="Add a file as virtio-blk disk (can be used multiple times)",
     )
 
     parser.add_argument(
@@ -1168,13 +1184,14 @@ class KernelSource:
             self.virtme_param["remote_cmd"] = ""
 
     def _get_virtme_disk(self, args):
-        if args.disk is not None:
-            disk_str = ""
-            for dsk in args.disk:
+        disk_str = ""
+        if args.scsi_disk is not None:
+            for dsk in args.scsi_disk:
+                disk_str += f"--scsi-disk {dsk}={dsk} "
+        if args.blk_disk is not None:
+            for dsk in args.blk_disk:
                 disk_str += f"--blk-disk {dsk}={dsk} "
-            self.virtme_param["disk"] = disk_str
-        else:
-            self.virtme_param["disk"] = ""
+        self.virtme_param["disk"] = disk_str
 
     def _get_virtme_sound(self, args):
         if args.sound:
@@ -1712,6 +1729,13 @@ def do_it() -> int:
     """Main body."""
     argcomplete.autocomplete(_ARGPARSER)
     args = _ARGPARSER.parse_args()
+
+    if args.disk:
+        sys.stderr.write(
+            "warning: `--disk` is deprecated, use `--blk-disk` instead.\n"
+        )
+        args.blk_disk.extend(args.disk)
+        args.disk = []
 
     # Handle --mcp option early (it's a server mode, not a normal
     # operation).

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -419,16 +419,22 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     parser.add_argument(
         "--scsi-disk",
         action="append",
-        metavar="PATH",
-        help="Add a file as virtio-scsi disk (can be used multiple times)",
+        metavar="[NAME=]PATH[,OPT...]",
+        help="Add a file as virtio-scsi disk (can be used multiple times), "
+        + "available at /dev/disk/by-id/scsi-0virtme_disk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
 
     parser.add_argument(
         "--blk-disk",
         "-D",
         action="append",
-        metavar="PATH",
-        help="Add a file as virtio-blk disk (can be used multiple times)",
+        metavar="[NAME=]PATH[,OPT...]",
+        help="Add a file as virtio-blk disk (can be used multiple times), "
+        + "available at /dev/disk/by-id/virtio-virtme_disk_blk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
 
     parser.add_argument(
@@ -1185,8 +1191,17 @@ class KernelSource:
 
     def _get_virtme_disk(self, args):
         def ensure_name(dsk: str) -> str:
-            if "=" not in dsk:
-                return f"{dsk}={dsk}"
+            """
+            `dsk` is a comma-separated list of disk options (KEY=VAL), with the first
+            option specifying the disk name and path (NAME=PATH). As an exception,
+            NAME can be omitted (but the underlying implementation does not know that).
+            This function ensures that the first option has a NAME, and adds one
+            equal to the PATH if it is missing.
+            """
+            items = dsk.split(",")
+            first = items[0]
+            if "=" not in first:
+                return f"{first}={dsk}"
             return dsk
 
         disk_str = ""
@@ -1738,9 +1753,7 @@ def do_it() -> int:
     args = _ARGPARSER.parse_args()
 
     if args.disk:
-        sys.stderr.write(
-            "warning: `--disk` is deprecated, use `--blk-disk` instead.\n"
-        )
+        sys.stderr.write("warning: `--disk` is deprecated, use `--blk-disk` instead.\n")
         args.blk_disk.extend(args.disk)
         args.disk = []
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -419,8 +419,11 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "--scsi-disk",
         action="append",
         default=[],
-        metavar="PATH",
-        help="Add a file as virtio-scsi disk (can be used multiple times)",
+        metavar="[NAME=]PATH[,OPT...]",
+        help="Add a file as virtio-scsi disk (can be used multiple times), "
+        + "available at /dev/disk/by-id/scsi-0virtme_disk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
 
     parser.add_argument(
@@ -428,8 +431,11 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "-D",
         action="append",
         default=[],
-        metavar="PATH",
-        help="Add a file as virtio-blk disk (can be used multiple times)",
+        metavar="[NAME=]PATH[,OPT...]",
+        help="Add a file as virtio-blk disk (can be used multiple times), "
+        + "available at /dev/disk/by-id/virtio-virtme_disk_blk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
 
     parser.add_argument(
@@ -1201,8 +1207,17 @@ class KernelSource:
 
     def _get_virtme_disk(self, args):
         def ensure_name(dsk: str) -> str:
-            if "=" not in dsk:
-                return f"{dsk}={dsk}"
+            """
+            `dsk` is a comma-separated list of disk options (KEY=VAL), with the first
+            option specifying the disk name and path (NAME=PATH). As an exception,
+            NAME can be omitted (but the underlying implementation does not know that).
+            This function ensures that the first option has a NAME, and adds one
+            equal to the PATH if it is missing.
+            """
+            items = dsk.split(",")
+            first = items[0]
+            if "=" not in first:
+                return f"{first}={dsk}"
             return dsk
 
         disk_str = ""
@@ -1655,9 +1670,7 @@ def do_it() -> int:
     args = _ARGPARSER.parse_args()
 
     if args.disk:
-        sys.stderr.write(
-            "warning: `--disk` is deprecated, use `--blk-disk` instead.\n"
-        )
+        sys.stderr.write("warning: `--disk` is deprecated, use `--blk-disk` instead.\n")
         args.blk_disk.extend(args.disk)
         args.disk = []
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1200,11 +1200,18 @@ class KernelSource:
             self.virtme_param["remote_cmd"] = ""
 
     def _get_virtme_disk(self, args):
+        def ensure_name(dsk: str) -> str:
+            if "=" not in dsk:
+                return f"{dsk}={dsk}"
+            return dsk
+
         disk_str = ""
         for dsk in args.scsi_disk:
-            disk_str += f"--scsi-disk {dsk}={dsk} "
+            dsk = ensure_name(dsk)
+            disk_str += f"--scsi-disk {shlex.quote(dsk)} "
         for dsk in args.blk_disk:
-            disk_str += f"--blk-disk {dsk}={dsk} "
+            dsk = ensure_name(dsk)
+            disk_str += f"--blk-disk {shlex.quote(dsk)} "
         self.virtme_param["disk"] = disk_str
 
     def _get_virtme_sound(self, args):

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -405,12 +405,31 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         + "The last octet will be incremented for the next network devices.",
     )
 
+    # legacy alias (`vng --disk` and `virtme-run --disk` behavior is historically inconsistent)
     parser.add_argument(
         "--disk",
-        "-D",
+        # "-D",  # explicitly moved to `--blk-disk` to preserve behavior
         action="append",
+        default=[],
+        metavar="PATH",
+        help=argparse.SUPPRESS,
+    )
+
+    parser.add_argument(
+        "--scsi-disk",
+        action="append",
+        default=[],
         metavar="PATH",
         help="Add a file as virtio-scsi disk (can be used multiple times)",
+    )
+
+    parser.add_argument(
+        "--blk-disk",
+        "-D",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Add a file as virtio-blk disk (can be used multiple times)",
     )
 
     parser.add_argument(
@@ -1181,13 +1200,12 @@ class KernelSource:
             self.virtme_param["remote_cmd"] = ""
 
     def _get_virtme_disk(self, args):
-        if args.disk is not None:
-            disk_str = ""
-            for dsk in args.disk:
-                disk_str += f"--blk-disk {dsk}={dsk} "
-            self.virtme_param["disk"] = disk_str
-        else:
-            self.virtme_param["disk"] = ""
+        disk_str = ""
+        for dsk in args.scsi_disk:
+            disk_str += f"--scsi-disk {dsk}={dsk} "
+        for dsk in args.blk_disk:
+            disk_str += f"--blk-disk {dsk}={dsk} "
+        self.virtme_param["disk"] = disk_str
 
     def _get_virtme_sound(self, args):
         if args.sound:
@@ -1628,6 +1646,13 @@ def do_it() -> int:
     """Main body."""
     argcomplete.autocomplete(_ARGPARSER)
     args = _ARGPARSER.parse_args()
+
+    if args.disk:
+        sys.stderr.write(
+            "warning: `--disk` is deprecated, use `--blk-disk` instead.\n"
+        )
+        args.blk_disk.extend(args.disk)
+        args.disk = []
 
     # Handle --mcp option early (it's a server mode, not a normal
     # operation).

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -414,12 +414,31 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         + "The last octet will be incremented for the next network devices.",
     )
 
+    # legacy alias (`vng --disk` and `virtme-run --disk` behavior is historically inconsistent)
     parser.add_argument(
         "--disk",
-        "-D",
+        # "-D",  # explicitly moved to `--blk-disk` to preserve behavior
         action="append",
+        default=[],
+        metavar="PATH",
+        help=argparse.SUPPRESS,
+    )
+
+    parser.add_argument(
+        "--scsi-disk",
+        action="append",
+        default=[],
         metavar="PATH",
         help="Add a file as virtio-scsi disk (can be used multiple times)",
+    )
+
+    parser.add_argument(
+        "--blk-disk",
+        "-D",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Add a file as virtio-blk disk (can be used multiple times)",
     )
 
     parser.add_argument(
@@ -1207,13 +1226,12 @@ class KernelSource:
             self.virtme_param["remote_cmd"] = ""
 
     def _get_virtme_disk(self, args):
-        if args.disk is not None:
-            disk_str = ""
-            for dsk in args.disk:
-                disk_str += f"--blk-disk {dsk}={dsk} "
-            self.virtme_param["disk"] = disk_str
-        else:
-            self.virtme_param["disk"] = ""
+        disk_str = ""
+        for dsk in args.scsi_disk:
+            disk_str += f"--scsi-disk {dsk}={dsk} "
+        for dsk in args.blk_disk:
+            disk_str += f"--blk-disk {dsk}={dsk} "
+        self.virtme_param["disk"] = disk_str
 
     def _get_virtme_sound(self, args):
         if args.sound:
@@ -1656,6 +1674,11 @@ def do_it() -> int:
     """Main body."""
     argcomplete.autocomplete(_ARGPARSER)
     args = _ARGPARSER.parse_args()
+
+    if args.disk:
+        sys.stderr.write("warning: `--disk` is deprecated, use `--blk-disk` instead.\n")
+        args.blk_disk.extend(args.disk)
+        args.disk = []
 
     # Handle --mcp option early (it's a server mode, not a normal
     # operation).

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -428,8 +428,11 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "--scsi-disk",
         action="append",
         default=[],
-        metavar="PATH",
-        help="Add a file as virtio-scsi disk (can be used multiple times)",
+        metavar="[NAME=]PATH[,OPT...]",
+        help="Add a file as virtio-scsi disk (can be used multiple times), "
+        + "available at /dev/disk/by-id/scsi-0virtme_disk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
 
     parser.add_argument(
@@ -437,8 +440,11 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "-D",
         action="append",
         default=[],
-        metavar="PATH",
-        help="Add a file as virtio-blk disk (can be used multiple times)",
+        metavar="[NAME=]PATH[,OPT...]",
+        help="Add a file as virtio-blk disk (can be used multiple times), "
+        + "available at /dev/disk/by-id/virtio-virtme_disk_blk_NAME. "
+        + "OPTs are comma-separated KEY[=VALUE] pairs; "
+        + "pass 'help' to list them.",
     )
 
     parser.add_argument(
@@ -1227,8 +1233,17 @@ class KernelSource:
 
     def _get_virtme_disk(self, args):
         def ensure_name(dsk: str) -> str:
-            if "=" not in dsk:
-                return f"{dsk}={dsk}"
+            """
+            `dsk` is a comma-separated list of disk options (KEY=VAL), with the first
+            option specifying the disk name and path (NAME=PATH). As an exception,
+            NAME can be omitted (but the underlying implementation does not know that).
+            This function ensures that the first option has a NAME, and adds one
+            equal to the PATH if it is missing.
+            """
+            items = dsk.split(",")
+            first = items[0]
+            if "=" not in first:
+                return f"{first}={dsk}"
             return dsk
 
         disk_str = ""

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1226,11 +1226,18 @@ class KernelSource:
             self.virtme_param["remote_cmd"] = ""
 
     def _get_virtme_disk(self, args):
+        def ensure_name(dsk: str) -> str:
+            if "=" not in dsk:
+                return f"{dsk}={dsk}"
+            return dsk
+
         disk_str = ""
         for dsk in args.scsi_disk:
-            disk_str += f"--scsi-disk {dsk}={dsk} "
+            dsk = ensure_name(dsk)
+            disk_str += f"--scsi-disk {shlex.quote(dsk)} "
         for dsk in args.blk_disk:
-            disk_str += f"--blk-disk {dsk}={dsk} "
+            dsk = ensure_name(dsk)
+            disk_str += f"--blk-disk {shlex.quote(dsk)} "
         self.virtme_param["disk"] = disk_str
 
     def _get_virtme_sound(self, args):

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -94,6 +94,15 @@ def get_conf(key_path):
         return conf
 
 
+def strtobool(arg: str) -> bool:
+    lower = arg.strip().lower()
+    if lower in ("yes", "true", "on", "1"):
+        return True
+    if lower in ("no", "false", "off", "0"):
+        return False
+    raise ValueError(f"invalid boolean value: {arg!r}")
+
+
 def scsi_device_id(name: str, max_len: int) -> str:
     """
     Trim a longer string which may or may not be a path to fit within `max_len`

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -4,6 +4,7 @@
 """virtme-ng: configuration path."""
 
 import json
+import os.path
 from pathlib import Path
 
 from virtme_ng.spinner import Spinner
@@ -91,3 +92,24 @@ def get_conf(key_path):
         for key in keys:
             conf = conf[key]
         return conf
+
+
+def scsi_device_id(name: str, max_len: int) -> str:
+    """
+    Trim a longer string which may or may not be a path to fit within `max_len`
+    characters.
+
+    Intended usage is to generate a `scsi-hd.device_id` value to fit within QEMU's
+    20 character limit. Normally, QEMU defaults `scsi-hd.device_id` to `scsi_hd.serial`,
+    which we set to the NAME provided in the `--disk` parameter (which, in turn,
+    defaults to the full path in the same parameter in `vng` CLI).
+    """
+    name = os.path.normpath(name)
+    # Try removing path components from the left first
+    while len(name) > max_len:
+        _left, sep, right = name.partition("/")
+        if not sep:
+            # still too long, truncate from the left
+            return name[-max_len:]
+        name = right
+    return name


### PR DESCRIPTION
Expand `vng`'s capabilities for configuring emulated disk drives. This has two meaningful parts.

First, this PR adds support to the `vng` wrapper for connecting both types of emulated disks to the VM. Originally, `vng` only accepted a `--disk` argument (which was internally translated to `vng --blk-disk`, despite the documentation), with no option to attach a SCSI disk using the `vng` wrapper (while at the same time, `virtme-ng --disk` had an opposite meaning).

This PR adds support for both `vng --scsi-disk` and `vng --blk-disk`, which now map 1:1 to identical `virtme-ng` options, and converts `vng --disk` / `virtme-ng --disk` into a legacy alias (with a warning on usage) due to its inconsistent behavior.

Second, this PR adds support to both `vng` and `virtme-run` for passing extended options in both `--scsi-disk` and `--blk-disk` arguments. Each value is now treated as a comma-separated list with a number of I/O driver options and disk topology options available.

There are several I/O driver options:

- `format=(raw|qcow2)` (with `raw` now explicitly passed to QEMU by default, since QEMU considers implicit format detection a deprecated feature and prohibits write operations to sector 0 if it is used)
- `cache=(...)` corresponds to QEMU's `-blockdev cache.*`, or `-drive cache=...`
- `aio=(...)` corresponds to QEMU's `-blockdev aio=...`, or `-drive aio=...`
- `discard=(on|off)` corresponds to QEMU's `-blockdev discard=(ignore|unmap)` or `-drive discard=...`
- `detect-zeroes=(on|off)` corresponds to QEMU's `-blockdev detect-zeroes=(on|off|unmap)` or `-drive detect-zeroes=...`
- `queues=(int)` corresponds to QEMU's `-device num_queues=...` on `virtio-blk-device` or `virtio-scsi-device` nodes

Then, there are topology options which change the characteristics and limits of the disk reported to the guest OS:

- `log-sec=(bytes)` sets the logical sector (LBA) size, e.g. to emulate 4Kn disks
- `phy-sec=(bytes)` sets the physical (underlying) sector size
- `min-io=(bytes)` sets the advisory minimum I/O size
- `opt-io=(bytes)` sets the advisory optimal I/O size
- `disc-gran=(bytes)` sets the advisory TRIM/UNMAP request granularity
- `rota=(on|off)` indicates whether the emulated drive is reported as rotational medium

Finally, there are two metaoptions:
- `iothread=(on|off)` adds a dedicated I/O thread for the disk and/or SCSI controller, and
- `topology=(on|off)` extracts host device topology data from sysfs and translates that into the values of the options above (naturally, this only works when the host path points to an actual block device).
