### PR TITLE
pre-commit: disable autofix and switch auto-updates to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ---
 ci:
+    autofix_prs: false
     autoupdate_schedule: monthly
     skip: [cargo-clippy-fix, cargo-clippy, cargo-check, cargo-fmt]
 


### PR DESCRIPTION
This is linked to discussions on #391.

To reduce noise, pre-commit.ci will now have less auto-updates and auto-fixes. See the explanations in the different commits for more details about that.

Link to the doc: https://pre-commit.ci/#configuration