### PR TITLE
virtme-ng-init: Mount /dev before logging

### DIFF
--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -1125,8 +1125,8 @@ fn print_logo() {
 fn main() {
     // Basic system initialization (order is important here).
     configure_environment();
-    configure_hostname();
     mount_kernel_filesystems();
+    configure_hostname();
     mount_cgroupfs();
     configure_limits();
     mount_virtme_overlays();


### PR DESCRIPTION
Ensure that mount_kernel_filesystems() is called before configure_hostname() to guarantee that /dev (specifically /dev/kmsg) is available before any code attempts to use the log!() macro.

Fix by swapping the order: run mount_kernel_filesystems() before configure_hostname().

Fixes: 71de7b5 ("virtme_ng_init: Add multiple missing log statements")