### PR TITLE
virtme-init: Mount /dev before logging

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -658,8 +658,8 @@ setup_user_session() {
 
 # Basic system initialization (order is important here).
 configure_environment
-configure_hostname
 mount_kernel_filesystems
+configure_hostname
 mount_cgroupfs
 configure_limits
 mount_virtme_overlays


### PR DESCRIPTION
Ensure that `mount_kernel_filesystems` is called before `configure_hostname` to guarantee that `/dev` (specifically `/dev/kmsg`) is available before any code attempts to use the `log` function.

See commit 954d73093116 ("virtme-ng-init: Mount /dev before logging").