### PR TITLE
systemd: Use a drop-in for serial-getty instead of a fragment

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -28,6 +28,7 @@ from typing import Any, NoReturn
 from virtme_ng.utils import (
     CACHE_DIR,
     DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR,
+    SERIAL_GETTY_DIR,
     SERIAL_GETTY_FILE,
     SSH_CONF_FILE,
     SSH_DIR,
@@ -1941,6 +1942,7 @@ def do_it() -> int:
                     continue
                 init_environment_vars.append(f"{match.group(1)}={match.group(2)}")
             os.makedirs(CACHE_DIR, exist_ok=True)
+            os.makedirs(SERIAL_GETTY_DIR, exist_ok=True)
             with open(SERIAL_GETTY_FILE, "w", encoding="utf-8") as f:
                 f.write(
                     f"""[Service]
@@ -1949,7 +1951,8 @@ StandardOutput=tty
 TTYPath=/dev/%I
 TTYReset=yes
 TTYVHangup=yes
-Environment={shlex.join(init_environment_vars)}"""
+Environment={shlex.join(init_environment_vars)}
+ExecStart="""
                 )
                 if args.root == "/":
                     f.write(f"\nExecStart={guest_tools_path}/{virtme_init_cmd}")

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -16,7 +16,8 @@ VIRTME_SSH_HOSTNAME_CID_SEPARATORS = ("%", "/")
 DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR = VIRTME_SSH_HOSTNAME_CID_SEPARATORS[0]
 CONF_PATH = Path(Path.home(), ".config", "virtme-ng")
 CONF_FILE = Path(CONF_PATH, "virtme-ng.conf")
-SERIAL_GETTY_FILE = Path(CACHE_DIR, "serial-getty@.service")
+SERIAL_GETTY_DIR = Path(CACHE_DIR, "serial-getty@.service.d")
+SERIAL_GETTY_FILE = Path(SERIAL_GETTY_DIR, "virtme-ng.conf")
 
 # NOTE: this must stay in sync with README.md
 CONF_DEFAULT = {


### PR DESCRIPTION
Old systemd versions do not support the use of partial unit fragments,
therefore let's override the system service with a drop-in replacement
instead. With this, we make sure virtme-init runs and therefore we don't
hit a login prompt, while also re-enabling `--exec` scripts. Tested in
SLE12-SP5 (systemd v228).