### PR TITLE
setuptools is not needed at runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,6 @@ setup(
     install_requires=[
         "argcomplete",
         "requests",
-        "setuptools",
     ],
     extras_require={
         "mcp": [


### PR DESCRIPTION
Hi,

I'm disussing this patch in Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1125855