### PR TITLE
setup.py: Remove setuptools from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,6 @@ setup(
     install_requires=[
         "argcomplete",
         "requests",
-        "setuptools",
     ],
     extras_require={
         "mcp": [


### PR DESCRIPTION
Setuptools are just required for build/instlal not for runtime. https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/

Context: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1125855