### PR TITLE
ppc64le: Enable virtiofs support

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -324,6 +324,10 @@ class Arch_ppc(Arch):
         self.gccname = "powerpc64le"
 
     @staticmethod
+    def virtiofs_support() -> bool:
+        return True
+
+    @staticmethod
     def qemuargs(is_native, use_kvm, use_gpu):
         ret = Arch.qemuargs(is_native, use_kvm, use_gpu)
         ret.extend(["-M", "pseries"])


### PR DESCRIPTION
While testing vng and running zypper to install new kernels, it was showing messages about rpm unknown db, like this:

virtme-ng:/ # zypper ref
warning: Rebuilding outdated index databases
rpmidxOpenXdb: Invalid argument
error: cannot open Name index using unknown db - Operation not permitted (1)

An strace run presented that the rpm binary was trying to execute flock system call, and it was failing. Ony then I found out that the VM was not using virtiofsd. After some research I discovered that 9pfs on qemu doesn't implement flock properly.

Either way, I found that if the virtiofs support is enabled the problem is gone, and it works properly.