### PR TITLE
virtme-init: Find correct busybox binary

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -330,6 +330,16 @@ override_system_files() {
     generate_lvm
 }
 
+find_busybox() {
+    if command -v busybox-static &> /dev/null; then
+        echo busybox-static
+    elif command -v busybox &> /dev/null; then
+        echo busybox
+    else
+        return 1
+    fi
+}
+
 setup_network() {
     local pids=()
 
@@ -340,6 +350,11 @@ setup_network() {
         # allows to run ping as regular user).
         echo "0 2147483647" > /proc/sys/net/ipv4/ping_group_range
 
+        if ! busybox="$(find_busybox)"; then
+            log "virtme-init: cannot find busybox (needed for udhcpc)"
+            return 1
+        fi
+
         # udev is liable to rename the interface out from under us.
         for d in /sys/bus/virtio/drivers/virtio_net/virtio*/net/*; do
             virtme_net=$(basename -- "${d}")
@@ -347,7 +362,7 @@ setup_network() {
             if [[ -n $virtme_hostname ]]; then
                 udhcpc_opts+=(-x hostname:"$virtme_hostname")
             fi
-            busybox udhcpc "${udhcpc_opts[@]}" &
+            "$busybox" udhcpc "${udhcpc_opts[@]}" &
             pids+=($!)
         done
         wait "${pids[@]}"


### PR DESCRIPTION
When using external roots with foreign architectures, virtme-ng depends on
busybox-static. However, it always use the `busybox` binary. Some distros
might install a different binary for the static variant, e.g.
`busybox-static`. Check if there is `busybox-static` in the $PATH to take
precedence over `busybox`.