### PR TITLE
Use per-VM QMP sockets and configurable GDB port

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -12,6 +12,7 @@ import shlex
 import shutil
 import signal
 import socket
+import stat
 import sys
 import tempfile
 import threading
@@ -210,6 +211,13 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         action="store_true",
         help="Attach a debugging session to a running instance started with --debug",
     )
+    parser.add_argument(
+        "--gdb-port",
+        action="store",
+        type=int,
+        default=1234,
+        help="GDB TCP port to use when --debug is enabled (default: 1234)",
+    )
 
     parser.add_argument(
         "--snaps", action="store_true", help="Allow to execute snaps inside virtme-ng"
@@ -218,7 +226,10 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     parser.add_argument(
         "--debug",
         action="store_true",
-        help="Start the instance with debugging enabled (allow to generate crash dumps)",
+        help=(
+            "Start the instance with debugging enabled (allow to generate crash dumps; "
+            "use --gdb-port to change the GDB port)"
+        ),
     )
 
     parser.add_argument(
@@ -716,6 +727,22 @@ def get_host_arch():
     return arch_map.get(arch, None)
 
 
+def _get_qmp_path(name):
+    base = name or socket.gethostname()
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", base)
+    return f"/tmp/virtme-ng-{safe}.qmp"
+
+
+def _qmp_socket_available(path):
+    if not os.path.exists(path):
+        return True
+    try:
+        st = os.stat(path)
+        return not stat.S_ISSOCK(st.st_mode)
+    except OSError:
+        return False
+
+
 class KernelSource:
     """Main class that implement actions to perform on a kernel source directory."""
 
@@ -723,6 +750,7 @@ class KernelSource:
         self.virtme_param = {}
         self.default_opts = get_conf("default_opts")
         self.cpus = str(os.cpu_count())
+        self.qmp_path = None
 
     def _format_cmd(self, cmd):
         return shlex.split(cmd)
@@ -1337,7 +1365,17 @@ class KernelSource:
         qemu_args = ""
         if args.debug or args.pin:
             # Enable debug mode and QMP (to trigger memory dump via `vng --dump`)
-            qemu_args += "-s -qmp tcp:localhost:3636,server,nowait "
+            qmp_path = _get_qmp_path(args.name)
+            if not _qmp_socket_available(qmp_path):
+                sys.stderr.write(
+                    "QMP socket already exists. Rerun with a unique --name or stop the existing VM.\n"
+                )
+                sys.exit(1)
+            self.qmp_path = qmp_path
+
+            gdb_port = args.gdb_port
+            qemu_args += f"-gdb tcp:127.0.0.1:{gdb_port} "
+            qemu_args += f"-qmp unix:{qmp_path},server,nowait "
         if args.qemu_opts is not None:
             qemu_args += " ".join(args.qemu_opts)
         if qemu_args != "":
@@ -1449,13 +1487,28 @@ class KernelSource:
         )
         if args.pin:
             self.set_affinity(args)
-        check_call(cmd, shell=True)
+        try:
+            check_call(cmd, shell=True)
+        finally:
+            # Cleanup the QMP socket
+            if self.qmp_path and os.path.exists(self.qmp_path):
+                try:
+                    os.remove(self.qmp_path)
+                except OSError:
+                    pass
 
     def dump(self, args):
         """Generate or analyze a crash memory dump."""
         # Use QMP to generate a memory dump
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect(("localhost", 3636))
+        qmp_path = _get_qmp_path(args.name)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.connect(qmp_path)
+        except (FileNotFoundError, ConnectionRefusedError):
+            sys.stderr.write(
+                "QMP connection failed (is the VM running with --debug or --pin?)\n"
+            )
+            sys.exit(1)
         sock_f = sock.makefile(encoding="utf-8")
         data = sock_f.readline()
         if not data:
@@ -1541,12 +1594,12 @@ class KernelSource:
         # Attempt QMP connection to the guest (retry up to 5 times)
         for attempt in range(5):
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                # TODO: support multiple vng guests. pylint: disable=W0511
-                sock.connect(("localhost", 3636))
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                qmp_path = _get_qmp_path(args.name)
+                sock.connect(qmp_path)
                 sock_f = sock.makefile(encoding="utf-8")
                 break
-            except ConnectionRefusedError:
+            except (FileNotFoundError, ConnectionRefusedError):
                 if attempt < 4:
                     time.sleep(1)
                 else:


### PR DESCRIPTION
**Motivation**
Our team needed to run multiple virtme-ng VMs on the same host, but QMP was hardcoded to a TCP
port, causing collisions. We switched QMP to a per‑VM Unix socket to remove the port
conflict, and made the GDB port configurable to avoid 1234 clashes when running multiple
debug sessions

**Summary**

Switch QMP to a Unix socket per VM name to avoid TCP port collisions.
Add --gdb-port to make the GDB stub port configurable (default 1234).
Improve error messaging when GDB port 1234 is already in use.
Add safety check for existing QMP sockets and auto-clean them on exit.

**Tests**
On the same VM
in one shell tab run .`/vng --debug --name instance1` (Will use the default gdb-port of 1234
in another tab run `./vng --debug --name instance2 --gdb-port 1235` (You have to define the --gdb-port since default is in use)
