### PR TITLE
virtme: Always set virtme_console kernel parameter

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1500,6 +1500,8 @@ def do_it() -> int:
     qemuargs.extend(["-parallel", "none"])
     qemuargs.extend(["-net", "none"])
 
+    kernelargs.extend(["virtme_console=" + arg for arg in arch.serial_console_args()])
+
     if args.graphics is None and not args.script_sh and not args.script_exec:
         qemuargs.extend(["-echr", "1"])
 
@@ -1541,10 +1543,6 @@ def do_it() -> int:
         qemuargs.extend(["-serial", "chardev:console"])
         if not args.disable_monitor:
             qemuargs.extend(["-mon", "chardev=console"])
-
-        kernelargs.extend(
-            ["virtme_console=" + arg for arg in arch.serial_console_args()]
-        )
 
         if args.nvgpu is None:
             qemuargs.extend(arch.qemu_nodisplay_args())


### PR DESCRIPTION
`virtme_console` is only set in the interactive path. In the script path (`--script-sh`, used by `vng --exec`), this can cause virtme-init to pick an invalid console on some external roots.

Set `virtme_console` unconditionally so virtme-init selects the intended serial console.