### PR TITLE
Add clean_exclude config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,20 @@ Configuration
   ```json
   {
       "default_opts": {},
+      "clean_exclude": [],
       "systemd": {
           "masks": ["getty@"],
           "fstab": "/dev/null"
       }
+  }
+  ```
+
+* `clean_exclude` is a list of patterns to exclude from `vng --clean`. Each
+  pattern is passed as a `-e <pattern>` argument to `git clean`. For example,
+  to preserve a `.semcode.db` file when running `vng --clean`:
+  ```json
+  {
+      "clean_exclude": [".semcode.db"]
   }
   ```
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1635,12 +1635,15 @@ class KernelSource:
         """Clean a local or remote git repository."""
         if not os.path.exists(".git"):
             arg_fail("error: must run from a kernel git repository", show_usage=False)
+        excludes = ""
+        for pattern in get_conf("clean_exclude"):
+            excludes += f" -e {shlex.quote(pattern)}"
         if args.build_host is None:
-            cmd = self._format_cmd("git clean -xdf")
+            cmd = self._format_cmd(f"git clean -xdf{excludes}")
         else:
             cmd = f"ssh {args.build_host} --"
             cmd = self._format_cmd(cmd)
-            cmd.append("cd ~/.virtme && git clean -xdf")
+            cmd.append(f"cd ~/.virtme && git clean -xdf{excludes}")
         check_call_cmd(cmd, quiet=not args.verbose, dry_run=args.dry_run)
 
 

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -22,6 +22,7 @@ SERIAL_GETTY_FILE = Path(SERIAL_GETTY_DIR, "virtme-ng.conf")
 # NOTE: this must stay in sync with README.md
 CONF_DEFAULT = {
     "default_opts": {},
+    "clean_exclude": [],
     "systemd": {
         "masks": [
             # disable getty@, since we're forcing the use of serial-getty@


### PR DESCRIPTION
Allow users to protect specific files from being removed by `vng --clean` by specifying git exclusion patterns in the virtme-ng config file. Each pattern in the `clean_exclude` list is passed as a `-e <pattern>` argument to `git clean`.

I noticed that the default index directory used by [semcode](https://github.com/facebookexperimental/semcode) gets partially cleaned by `vng --clean` so I opened this PR to be able to disable this for me.

That being said, I kind of wonder if we should make excluding `.semcode.db` default because ahh I could see the way that indexes things (which is incredibly useful) generating a lot of traffic if clean cleans them (and automation, etc.).

```
❯ ~/.local/bin/vng --clean

❯ ls .semcode.db
 .semcode.db

❯ /usr/bin/vng --clean

❯ ls .semcode.db
lsd: .semcode.db: No such file or directory (os error 2).
```
