### PR TITLE
virtme: gdb server: boot with nokaslr

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1628,6 +1628,7 @@ def do_it() -> int:
 
     if args.gdb_server is not None:
         qemuargs.extend(["-gdb", f"tcp:localhost:{args.gdb_server}"])
+        kernelargs.extend(["-a", "nokaslr"])
 
     ret_path = None
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1234,8 +1234,6 @@ class KernelSource:
                 split_items = shlex.split(item)
                 for split_item in split_items:
                     append += ["-a", split_item]
-        if args.debug:
-            append += ["-a", "nokaslr"]
 
         # Set default user's shell override, if specified.
         if args.shell is not None:


### PR DESCRIPTION
According to commit 8bc1dfa ("virtme-ng: boot with nokaslr when --debug is used"), kernel address space randomization can prevent resolving kernel symbols externally, which is needed when using GDB.

If this was set for GDB, set it together with GDB, that's clearer than setting it in the middle of other `--kopt` options.