### PR TITLE
virtme: Treat root as a valid overlay for --rwdir

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1490,8 +1490,9 @@ def do_it() -> int:
         # Check if paths are accessible both on the host and the guest.
         if not os.path.exists(hostpath):
             arg_fail(f"error: cannot access {hostpath} on the host")
-        # Guest path must be defined inside one of the overlays
-        guest_path_ok = False
+        # Guest path must be defined inside a valid overlay (root or overlay_rwdir).
+        # The root is always mounted in the guest, so any path under root is valid.
+        guest_path_ok = not os.path.normpath(guestpath).startswith("..")
         for d in args.overlay_rwdir:
             if os.path.exists(guestpath) or is_subpath(guestpath, d):
                 guest_path_ok = True


### PR DESCRIPTION
The guest-path check for --rwdir only considered overlay_rwdir when the path is inside a valid overlay. However, it never treats the root filesystem as valid. So single-arg --rwdir could fail with:

  error: cannot initialize ... inside the guest (path must be defined inside a valid overlay)

Fix by considering the root a valid overlay, so --rwdir with a single argument works for any path under root without relying on default overlay_rwdir or cwd.

This fixes #409.