### PR TITLE
virtme: Allow to run without a valid PTS

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1674,80 +1674,103 @@ def do_it() -> int:
         except FileNotFoundError:
             return None
 
+    def add_serial_port(chardev_spec: str, chardev_id: str, port_name: str) -> None:
+        """Add a chardev, virtio-serial device, and virtserialport for script I/O."""
+        qemuargs.extend(["-chardev", chardev_spec])
+        qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
+        qemuargs.extend(
+            ["-device", f"virtserialport,name={port_name},chardev={chardev_id}"]
+        )
+
     def do_script(shellcmd: str, ret_path=None, show_boot_console=False) -> None:
         if args.graphics is None:
-            # Turn off default I/O
             if args.nvgpu is None:
                 qemuargs.extend(arch.qemu_nodisplay_args())
             else:
                 qemuargs.extend(arch.qemu_nodisplay_nvgpu_args())
 
-        # Check if we can redirect stdin/stdout/stderr.
-        if (
-            not can_access_file("/proc/self/fd/0")
-            or not can_access_file("/proc/self/fd/1")
-            or not can_access_file("/proc/self/fd/2")
-        ):
-            print(
-                "ERROR: not a valid pts, try to run vng with a valid PTS "
-                "(e.g., inside tmux or screen)",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        # Configure kernel console output
+        # Kernel console: where to send boot/console output.
         if show_boot_console:
-            output = "/proc/self/fd/2"
+            console_output = "/proc/self/fd/2"
             console_args = ()
         else:
-            output = "/dev/null"
+            console_output = "/dev/null"
             console_args = ["quiet", "loglevel=0"]
-        qemuargs.extend(arch.qemu_serial_console_args())
-        qemuargs.extend(["-chardev", f"file,id=console,path={output}"])
 
-        kernelargs.extend(["console=" + arg for arg in arch.serial_console_args()])
-        kernelargs.extend(arch.earlyconsole_args())
-        kernelargs.extend(console_args)
+        fds_accessible = all(can_access_file(f"/proc/self/fd/{i}") for i in (0, 1, 2))
+        if fds_accessible:
+            # Valid stdin/stdout/stderr: console & script I/O use host fds.
+            qemuargs.extend(arch.qemu_serial_console_args())
+            qemuargs.extend(["-chardev", f"file,id=console,path={console_output}"])
+            kernelargs.extend(["console=" + arg for arg in arch.serial_console_args()])
+            kernelargs.extend(arch.earlyconsole_args())
+            kernelargs.extend(console_args)
 
-        # Set up a virtserialport for script I/O
-        #
-        # NOTE: we need two additional I/O ports for /dev/stdout and
-        # /dev/stderr in the guest.
-        #
-        # This is needed because virtio serial ports are designed to support a
-        # single writer at a time, so any attempt to write directly to
-        # /dev/stdout or /dev/stderr in the guest will result in an -EBUSY
-        # error.
-        qemuargs.extend(["-chardev", "stdio,id=stdin,signal=on,mux=off"])
-        qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
-        qemuargs.extend(["-device", "virtserialport,name=virtme.stdin,chardev=stdin"])
+            # Script I/O ports (guest /dev/stdout, /dev/stderr). Virtio serial
+            # allows only one writer per port, so we need separate ports for
+            # script stdout/stderr and for direct /dev/stdout/err writes.
+            add_serial_port("stdio,id=stdin,signal=on,mux=off", "stdin", "virtme.stdin")
+            add_serial_port(
+                "file,id=stdout,path=/proc/self/fd/1", "stdout", "virtme.stdout"
+            )
+            add_serial_port(
+                "file,id=stderr,path=/proc/self/fd/2", "stderr", "virtme.stderr"
+            )
+            add_serial_port(
+                "file,id=dev_stdout,path=/proc/self/fd/1",
+                "dev_stdout",
+                "virtme.dev_stdout",
+            )
+            add_serial_port(
+                "file,id=dev_stderr,path=/proc/self/fd/2",
+                "dev_stderr",
+                "virtme.dev_stderr",
+            )
+        else:
+            # No valid stdin/stdout/stderr: warn and use console only. QEMU
+            # allows one stdio chardev; with -v we use it for the console
+            # (guest uses console fallback). Without -v we use /dev/null
+            # for console and optionally add script I/O with stdio for
+            # stdout so command output is visible.
+            print(
+                "WARNING: stdin/stdout/stderr not accessible via /proc/self/fd, "
+                "falling back to limited redirection (stderr may be lost).\n"
+                "If full redirection is needed, run vng with: \n"
+                "script -q -c 'vng -- <command>'\n"
+                "(or use tmux/screen)",
+                file=sys.stderr,
+                flush=True,
+            )
+            if show_boot_console:
+                qemuargs.extend(["-chardev", "stdio,id=console,signal=off,mux=off"])
+            else:
+                qemuargs.extend(["-chardev", "file,id=console,path=/dev/null"])
+            qemuargs.extend(["-serial", "chardev:console"])
+            kernelargs.extend(["console=" + arg for arg in arch.serial_console_args()])
+            kernelargs.extend(arch.earlyconsole_args())
+            kernelargs.extend(console_args)
 
-        qemuargs.extend(["-chardev", "file,id=stdout,path=/proc/self/fd/1"])
-        qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
-        qemuargs.extend(["-device", "virtserialport,name=virtme.stdout,chardev=stdout"])
+            if not show_boot_console:
+                add_serial_port("file,id=stdin,path=/dev/null", "stdin", "virtme.stdin")
+                add_serial_port(
+                    "stdio,id=stdout,signal=off,mux=off", "stdout", "virtme.stdout"
+                )
+                add_serial_port(
+                    "file,id=dev_stdout,path=/dev/null",
+                    "dev_stdout",
+                    "virtme.dev_stdout",
+                )
+                add_serial_port(
+                    "file,id=stderr,path=/dev/null", "stderr", "virtme.stderr"
+                )
+                add_serial_port(
+                    "file,id=dev_stderr,path=/dev/null",
+                    "dev_stderr",
+                    "virtme.dev_stderr",
+                )
 
-        qemuargs.extend(["-chardev", "file,id=stderr,path=/proc/self/fd/2"])
-        qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
-        qemuargs.extend(["-device", "virtserialport,name=virtme.stderr,chardev=stderr"])
-
-        qemuargs.extend(["-chardev", "file,id=dev_stdout,path=/proc/self/fd/1"])
-        qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
-        qemuargs.extend(
-            ["-device", "virtserialport,name=virtme.dev_stdout,chardev=dev_stdout"]
-        )
-
-        qemuargs.extend(["-chardev", "file,id=dev_stderr,path=/proc/self/fd/2"])
-        qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
-        qemuargs.extend(
-            ["-device", "virtserialport,name=virtme.dev_stderr,chardev=dev_stderr"]
-        )
-
-        # Create a virtio serial device to channel the retcode of the script
-        # executed in the guest to the host.
         if ret_path is not None:
-            qemuargs.extend(["-chardev", f"file,id=ret,path={ret_path}"])
-            qemuargs.extend(["-device", arch.virtio_dev_type("serial")])
-            qemuargs.extend(["-device", "virtserialport,name=virtme.ret,chardev=ret"])
+            add_serial_port(f"file,id=ret,path={ret_path}", "ret", "virtme.ret")
 
         # Scripts shouldn't reboot and shouldn't hang on panic: make sure to
         # force an exit condition if a panic happens.
@@ -1793,8 +1816,11 @@ def do_it() -> int:
         )
 
     if args.script_exec is not None:
+        _, ret_path = tempfile.mkstemp(prefix="virtme_ret")
+        atexit.register(cleanup_script_retcode)
         do_script(
             shlex.quote(args.script_exec),
+            ret_path=ret_path,
             show_boot_console=args.show_boot_console,
         )
 

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -419,6 +419,8 @@ poweroff_and_exit() {
     exit "$rc"
 }
 
+# Run the user script. Returns 1 if script I/O ports are missing (caller may use console fallback).
+# Does not return when ports exist (runs script and poweroff).
 run_user_script() {
     local uid=$1
 
@@ -428,7 +430,7 @@ run_user_script() {
         ! -e "/dev/virtio-ports/virtme.dev_stdout" ||
         ! -e "/dev/virtio-ports/virtme.dev_stderr" ]]; then
         log "virtme-init: cannot find script I/O ports; make sure virtio-serial is available"
-        poweroff_and_exit 1
+        return 1
     fi
 
     # Set proper ownership on the virtio-ports devices
@@ -479,8 +481,35 @@ run_user_script() {
     poweroff_and_exit 0
 }
 
+# Run the user script with stdin/stdout/stderr on the serial console.
+# Used when virtme.exec is set but script I/O virtio ports are not available (e.g. no PTS on host).
+run_user_script_on_console() {
+    local consdev=$1 uid=$2
+
+    chown -- "$uid" "/dev/$consdev"
+    clear_virtme_envs
+
+    log 'starting script (console fallback)'
+    if [[ -n ${virtme_user:-} ]]; then
+        chmod +x /run/tmp/.virtme-script
+        setsid su -c /run/tmp/.virtme-script -- "${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
+    else
+        setsid bash /run/tmp/.virtme-script 0<> "/dev/$consdev" 1>&0 2>&0
+    fi
+    ret=$?
+    log "script returned {$ret}"
+
+    if [ -e /dev/virtio-ports/virtme.ret ]; then
+        echo "$ret" > /dev/virtio-ports/virtme.ret
+    fi
+    poweroff_and_exit 0
+}
+
 setup_user_script() {
     local uid=$1
+
+    # Unset so we don't carry over from a previous run
+    unset -v script_ports_missing
 
     user_cmd=$(sed -ne "s/.*virtme.exec=\`\([^\`]*\)\`.*/\1/p" /proc/cmdline)
     if [[ -n ${user_cmd} ]]; then
@@ -488,8 +517,8 @@ setup_user_script() {
         printf -- '%s\n' "$user_cmd" | base64 -d > /run/tmp/.virtme-script
 
         if [[ -z ${virtme_graphics:-} ]]; then
-            # Start the script
-            run_user_script "$uid"
+            # Start the script (returns 1 if script I/O ports are missing)
+            run_user_script "$uid" || script_ports_missing=1
         fi
     fi
 }
@@ -642,6 +671,11 @@ run_user_session() {
     local consdev=$1 uid=$2
 
     setup_user_script "$uid"
+
+    # Script mode but script I/O ports were missing; run script on console and exit.
+    if [[ -n "${script_ports_missing:-}" ]]; then
+        run_user_script_on_console "$consdev" "$uid"
+    fi
 
     if [[ -n ${virtme_graphics:-} ]]; then
         run_user_gui "$consdev" "$uid"

--- a/virtme_ng/mcp.py
+++ b/virtme_ng/mcp.py
@@ -159,22 +159,24 @@ IMPORTANT NOTES FOR AI AGENTS:
    Example with complex script:
      run_kernel_cmd({"command": "cd /path && ./test.sh && dmesg | tail -50"})
 
-3. PTS (Pseudo-Terminal) Requirement
-   -----------------------------------
-   virtme-ng (vng) requires a valid pseudo-terminal (PTS) to run. In automated
-   environments without a real terminal, vng commands will fail with:
-     "ERROR: not a valid pts, try to run vng with a valid PTS (e.g., inside tmux or screen)"
+3. PTS (Pseudo-Terminal) and Automated Environments
+   -------------------------------------------------
+   In environments without a real terminal (e.g. AI agent sessions), vng runs
+   but prints a warning: stdin/stdout/stderr redirection may not work. For
+   many use cases (e.g. run_kernel_cmd with non-interactive commands) this is
+   fine and vng still works.
 
-   This MCP server's run_kernel_cmd tool automatically handles PTS requirements by wrapping
-   commands with 'script'.
-
-   For direct shell commands, use 'script' to provide a PTS:
+   If you need a valid PTS (interactive use, reliable output capture), wrap
+   vng with 'script':
      script -q -c "vng -- command" /dev/null 2>&1
 
    The 'script' command:
      -q: Quiet mode (no script start/stop messages)
      -c: Execute command and exit
      /dev/null: Discard the typescript file (we only need stdout/stderr)
+
+   This MCP server's run_kernel_cmd tool suggests 'script' in generated
+   commands when a PTS may be needed.
 
 4. Typical Workflow for Testing Kernel Changes
    ============================================

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -755,7 +755,8 @@ fn extract_user_script(virtme_script: &str) -> Option<String> {
     String::from_utf8(BASE64.decode(encoded_cmd).ok()?).ok()
 }
 
-fn run_user_script(uid: u32) {
+/// Returns true if the script was run (and will poweroff), false if script I/O ports are missing.
+fn run_user_script(uid: u32) -> bool {
     if !Path::new("/dev/virtio-ports/virtme.stdin").exists()
         || !Path::new("/dev/virtio-ports/virtme.stdout").exists()
         || !Path::new("/dev/virtio-ports/virtme.stderr").exists()
@@ -763,7 +764,9 @@ fn run_user_script(uid: u32) {
         || !Path::new("/dev/virtio-ports/virtme.dev_stderr").exists()
     {
         log!("virtme-init: cannot find script I/O ports; make sure virtio-serial is available",);
-    } else {
+        return false;
+    }
+    {
         // Re-create stdout/stderr to connect to the virtio-serial ports.
         let io_files = [
             ("/dev/virtio-ports/virtme.ret", "/dev/virtme.ret"),
@@ -830,21 +833,77 @@ fn run_user_script(uid: u32) {
         }
         poweroff();
     }
+    true
 }
 
 fn create_user_script(cmd: &str) {
     utils::create_file(USER_SCRIPT, 0o0755, cmd).expect("Failed to create virtme-script file");
 }
 
-fn setup_user_script(uid: u32) {
+/// Run the user script with stdin/stdout/stderr on the serial console.
+/// Used when virtme.exec is set but script I/O virtio ports are not available (e.g. no PTS on host).
+fn run_user_script_on_console(consdev: &str, uid: u32) {
+    let flags = OFlag::O_RDWR;
+    let mode = Mode::empty();
+    let tty_fd = open(consdev, flags, mode).expect("failed to open console for script");
+
+    utils::do_chown(consdev, uid, None).ok();
+    clear_virtme_envs();
+
+    let user = env::var("virtme_user").unwrap_or_else(|_| String::new());
+    let (cmd, args) = if user.is_empty() {
+        ("/bin/sh", vec![USER_SCRIPT])
+    } else {
+        ("su", vec!["-c", USER_SCRIPT, "--", user.as_str()])
+    };
+
+    log!("starting script (console fallback)");
+    unsafe {
+        let ret = Command::new(cmd)
+            .args(&args)
+            .pre_exec(move || {
+                libc::setsid();
+                libc::close(libc::STDIN_FILENO);
+                libc::close(libc::STDOUT_FILENO);
+                libc::close(libc::STDERR_FILENO);
+                libc::dup2(tty_fd, libc::STDIN_FILENO);
+                libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 1);
+                libc::dup2(tty_fd, libc::STDOUT_FILENO);
+                libc::dup2(tty_fd, libc::STDERR_FILENO);
+                Ok(())
+            })
+            .output()
+            .expect("Failed to execute script on console");
+        if let Some(code) = ret.status.code() {
+            log!("script exited with code {}", code);
+            if let Ok(mut file) = OpenOptions::new()
+                .write(true)
+                .open("/dev/virtio-ports/virtme.ret")
+            {
+                let _ = file.write_all(code.to_string().as_bytes());
+            }
+        } else if let Ok(mut file) = OpenOptions::new()
+            .write(true)
+            .open("/dev/virtio-ports/virtme.ret")
+        {
+            let _ = file.write_all(b"-1");
+        }
+    }
+    poweroff();
+}
+
+/// Returns true if we are in script mode but could not run the script (script I/O ports missing).
+/// Caller should then run the script on the console and poweroff.
+fn setup_user_script(uid: u32) -> bool {
     if let Ok(cmdline) = std::fs::read_to_string("/proc/cmdline") {
         if let Some(cmd) = extract_user_script(&cmdline) {
             create_user_script(&cmd);
-            if env::var("virtme_graphics").is_err() {
-                run_user_script(uid);
+            if env::var("virtme_graphics").is_err() && !run_user_script(uid) {
+                return true; // script mode but ports missing
             }
         }
     }
+    false
 }
 
 fn setup_root_home() {
@@ -1018,7 +1077,10 @@ fn run_user_session(consdev: &str, uid: u32) {
     let mode = Mode::empty();
     let tty_fd = open(consdev, flags, mode).expect("failed to open console");
 
-    setup_user_script(uid);
+    if setup_user_script(uid) {
+        // Script mode but script I/O ports were missing; run script on console and exit.
+        run_user_script_on_console(consdev, uid);
+    }
 
     if env::var("virtme_graphics").is_ok() {
         run_user_gui(tty_fd);


### PR DESCRIPTION
vng currently exits with an error if stdin/stdout/stderr are not accessible via /proc/self/fd (e.g., when no pseudo-terminal is present). This breaks some environments, such as AI agent sessions.

A possible workaround is to run vng under `script` (as documented in virtme_ng/mcp.py), but it might be tricky for AI agents to figure this out without explicit guidance.

In practice, the absence of a valid PTS only affects host->guest stdio redirection, the guest can still boot and execute the requested command and most use cases only depend on the command result / exit status rather than stdin/stdio forwarding.

Therefore, change the error to a warning and suggest wrapping `vng` with `script` when redirection is needed.

This makes vng easily usable by AI agents without additional guidance.