### PR TITLE
vng: add --vfio-pci option for PCI device passthrough

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -388,6 +388,13 @@ def make_parser() -> argparse.ArgumentParser:
         "--nvgpu", action="store", default=None, help="Set guest NVIDIA GPU."
     )
 
+    g.add_argument(
+        "--vfio-pci",
+        action="append",
+        default=[],
+        help="Pass through a PCI device using vfio-pci (can be used multiple times).",
+    )
+
     g = parser.add_argument_group(title="Remote Console")
     cli_srv_choices = ["console", "ssh"]
     g.add_argument(
@@ -1924,6 +1931,9 @@ def do_it() -> int:
 
     if args.nvgpu:
         qemuargs.extend(["-device", args.nvgpu])
+
+    for addr in args.vfio_pci:
+        qemuargs.extend(["-device", f"vfio-pci,host={addr}"])
 
     # If we are running as root on the host, or using root user within an
     # external root filesystem, pass this information to the guest (this can be

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -544,6 +544,14 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         help="Add a passthrough NVIDIA GPU",
     )
 
+    parser.add_argument(
+        "--vfio-pci",
+        action="append",
+        metavar="PCI_ADDRESS",
+        help="Pass through a PCI device using vfio-pci (can be used multiple times), "
+        "e.g. --vfio-pci 0000:ce:00.0",
+    )
+
     g_remote = parser.add_argument_group(title="Remote Console")
 
     g_remote.add_argument(
@@ -1352,6 +1360,15 @@ class KernelSource:
         else:
             self.virtme_param["nvgpu"] = ""
 
+    def _get_virtme_vfio_pci(self, args):
+        if args.vfio_pci is not None:
+            vfio_str = " ".join(
+                f"--vfio-pci {shlex.quote(addr)}" for addr in args.vfio_pci
+            )
+            self.virtme_param["vfio_pci"] = vfio_str
+        else:
+            self.virtme_param["vfio_pci"] = ""
+
     def _get_virtme_qemu_opts(self, args):
         if args.qemu_opts is not None:
             self.virtme_param["qemu_opts"] = "--qemu-opts " + " ".join(args.qemu_opts)
@@ -1407,6 +1424,7 @@ class KernelSource:
         self._get_virtme_empty_passwords(args)
         self._get_virtme_busybox(args)
         self._get_virtme_nvgpu(args)
+        self._get_virtme_vfio_pci(args)
         self._get_virtme_qemu(args)
         self._get_virtme_qemu_opts(args)
 
@@ -1460,6 +1478,7 @@ class KernelSource:
             + f"{self.virtme_param['snaps']} "
             + f"{self.virtme_param['busybox']} "
             + f"{self.virtme_param['nvgpu']} "
+            + f"{self.virtme_param['vfio_pci']} "
             + f"{self.virtme_param['qemu']} "
             + f"{self.virtme_param['qemu_opts']} "
             # Important: qemu_opts has to be the last one


### PR DESCRIPTION
Allow passing through PCI devices to the guest using vfio-pci. The option can be used multiple times to pass through multiple devices, e.g. --vfio-pci 0000:ce:00.0 --vfio-pci 0000:cf:00.0

Each instance adds "-device vfio-pci,host=<PCI_ADDRESS>" to the QEMU command line.