### PR TITLE
virtme-init: Reap zombie processes

### DIFF
--- a/virtme_ng_init/Cargo.toml
+++ b/virtme_ng_init/Cargo.toml
@@ -18,5 +18,5 @@ unused_qualifications = "warn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nix = { version = "0.29", features = ["feature", "fs", "hostname", "mount", "reboot", "user"] }
+nix = { version = "0.29", features = ["feature", "fs", "hostname", "mount", "reboot", "user", "process"] }
 base64 = "0.22"

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -19,6 +19,7 @@ use nix::libc;
 use nix::sys::reboot;
 use nix::sys::stat::Mode;
 use nix::sys::utsname::uname;
+use nix::sys::wait::wait;
 use nix::unistd::sethostname;
 use std::env;
 use std::fs::{File, OpenOptions};
@@ -201,6 +202,28 @@ fn poweroff() {
         Err(err) => {
             log!("error powering off: {}", err);
             exit(1);
+        }
+    }
+}
+
+fn wait_for_child(child: i32) -> Option<i32> {
+    loop {
+        match wait() {
+            Ok(status) => {
+                if status.pid().is_some_and(|p| p.as_raw() == child) {
+                    use nix::sys::wait::WaitStatus;
+                    match status {
+                        WaitStatus::Exited(_, code) => return Some(code),
+                        WaitStatus::Signaled(_, _, _) => return None,
+                        _ => return None,
+                    }
+                }
+            }
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(err) => {
+                log!("error waiting for child process: {}", err);
+                return None;
+            }
         }
     }
 }
@@ -771,6 +794,8 @@ fn extract_user_script(virtme_script: &str) -> Option<String> {
 }
 
 /// Returns true if the script was run (and will poweroff), false if script I/O ports are missing.
+// wait_for_child is used to wait for the script process.
+#[allow(clippy::zombie_processes)]
 fn run_user_script(uid: u32) -> bool {
     if !Path::new("/dev/virtio-ports/virtme.stdin").exists()
         || !Path::new("/dev/virtio-ports/virtme.stdout").exists()
@@ -817,7 +842,7 @@ fn run_user_script(uid: u32) -> bool {
         clear_virtme_envs();
         log!("starting script");
         unsafe {
-            let ret = Command::new(cmd)
+            let child = Command::new(cmd)
                 .args(&args)
                 .pre_exec(move || {
                     libc::setsid();
@@ -831,17 +856,19 @@ fn run_user_script(uid: u32) -> bool {
                     libc::dup2(tty_err, libc::STDERR_FILENO);
                     Ok(())
                 })
-                .output()
-                .expect("Failed to execute script");
+                .spawn()
+                .expect("Failed to start user script process");
+
+            let ret = wait_for_child(child.id() as i32);
 
             // Channel the return code to the host via /dev/virtme.ret
             if let Ok(mut file) = OpenOptions::new().write(true).open("/dev/virtme.ret") {
                 // Write the value of output.status.code() to the file
-                if let Some(code) = ret.status.code() {
+                if let Some(code) = ret {
                     file.write_all(code.to_string().as_bytes())
                         .expect("Failed to write to file");
                 } else {
-                    // Handle the case where output.status.code() is None
+                    // Handle the case where the return code is None
                     file.write_all(b"-1").expect("Failed to write to file");
                 }
             }
@@ -1001,16 +1028,19 @@ fn detach_from_terminal(tty_fd: libc::c_int) {
     }
 }
 
+// wait_for_child is used to wait for the shell command.
+#[allow(clippy::zombie_processes)]
 fn run_shell(tty_fd: libc::c_int, cmd: &str, args: &[&str]) {
     unsafe {
-        Command::new(cmd)
+        let child = Command::new(cmd)
             .args(args)
             .pre_exec(move || {
                 detach_from_terminal(tty_fd);
                 Ok(())
             })
-            .output()
+            .spawn()
             .expect("Failed to start shell session");
+        wait_for_child(child.id() as i32);
     }
 }
 


### PR DESCRIPTION
If the users create ofphaned processes, it's init's task to reap them or else they'll remain as zombies.

For example:

```
vng --user root
          _      _
   __   _(_)_ __| |_ _ __ ___   ___       _ __   __ _
   \ \ / / |  __| __|  _   _ \ / _ \_____|  _ \ / _  |
    \ V /| | |  | |_| | | | | |  __/_____| | | | (_| |
     \_/ |_|_|   \__|_| |_| |_|\___|     |_| |_|\__  |
                                                |___/
   kernel version: 6.19.0-virtme x86_64
   (CTRL+d to exit)

bash-5.3# (setsid sleep 1 &); sleep 2; ps aux | grep 'sleep'
root       342  0.0  0.0      0     0 ?        Zs   18:11   0:00 [sleep] <defunct>
root       345  0.0  0.0   3464  1932 ttyS0    S+   18:11   0:00 grep 'sleep'
bash-5.3#
```

Replace the specific waitpid (internal to `Command::output()`) with a simple loop that will also reap zombies if they appear.