### PR TITLE
vng: Print --kconfig output with --dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ Examples
    $ vng --kconfig
    ```
 
+ - Print to stdout the kernel config flags set by virtme-ng:
+   ```shell
+   $ vng --kconfig --dry-run
+   ```
+
  - Run a kernel previously compiled from a local git repository in the current
    working directory:
    ```shell

--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -71,6 +71,12 @@ def make_parser():
         help="get chatty about config assembled",
     )
 
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved minimal virtme config flags to stdout and exit",
+    )
+
     g = parser.add_argument_group(title="Mode").add_mutually_exclusive_group()
 
     g.add_argument(
@@ -310,7 +316,7 @@ def do_it():
             os.environ["KBUILD_OUTPUT"] = var[2:]
 
     config_dir = os.environ.get("KBUILD_OUTPUT")
-    if config_dir is not None:
+    if config_dir is not None and not args.dry_run:
         try:
             os.makedirs(config_dir, exist_ok=True)
         except Exception as exc:
@@ -319,7 +325,7 @@ def do_it():
         config = os.path.join(config_dir, config)
         makef = os.path.join(config_dir, makef)
 
-    if os.path.exists(config):
+    if not args.dry_run and os.path.exists(config):
         if args.no_update:
             print(f"{config} file exists: no modifications have been done")
             return 0
@@ -356,6 +362,11 @@ def do_it():
 
     if args.verbose:
         print(f"conf:\n{conf}")
+
+    if args.dry_run:
+        for conf_item in conf:
+            print(conf_item.rstrip("\n"))
+        return 0
 
     linuxname = shlex.quote(arch.linuxname)
     archargs = [f"ARCH={linuxname}"]

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -758,6 +758,9 @@ class KernelSource:
         """Perform a make config operation on a kernel source directory."""
         arch = args.arch
         cmd = ["virtme-configkernel", "--defconfig"]
+        configkernel_dry_run = args.kconfig and args.dry_run
+        if configkernel_dry_run:
+            cmd.append("--dry-run")
         if args.verbose:
             cmd.append("--verbose")
         if not args.force and not args.kconfig:
@@ -780,7 +783,12 @@ class KernelSource:
         cmd += args.envs
         if args.verbose:
             print(f"cmd: {shlex.join(cmd)}")
-        check_call_cmd(cmd, quiet=not args.verbose, dry_run=args.dry_run)
+        quiet = not args.verbose and not configkernel_dry_run
+        check_call_cmd(
+            cmd,
+            quiet=quiet,
+            dry_run=args.dry_run and not configkernel_dry_run,
+        )
 
     def _make_remote(self, args, make_command):
         check_call_cmd(


### PR DESCRIPTION
Add a --dry-run mode to  virtme-configkernel that prints the assembled
config lines to stdout and exits.

Wire vng to pass --dry-run through when used with --kconfig, while
keeping the existing dry-run behavior for non-kconfig paths. In this
mode, avoid creating KBUILD_OUTPUT or writing .config.