### PR TITLE
vng: keep /tmp overlay in --rw mode

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1018,26 +1018,26 @@ class KernelSource:
             self.virtme_param["rwdir"] += f"--rwdir {item} "
 
     def _get_virtme_overlay_rwdir(self, args):
-        # Set default overlays if rootfs is mounted in read-only mode.
         if args.rw:
-            self.virtme_param["overlay_rwdir"] = ""
+            dirs = ["/tmp"]
         else:
-            self.virtme_param["overlay_rwdir"] = " ".join(
-                f"--overlay-rwdir {d}"
-                for d in (
-                    "/etc",
-                    "/lib",
-                    "/home",
-                    "/opt",
-                    "/srv",
-                    "/usr",
-                    "/var",
-                    "/tmp",
-                )
-            )
+            dirs = [
+                "/etc",
+                "/lib",
+                "/home",
+                "/opt",
+                "/srv",
+                "/usr",
+                "/var",
+                "/tmp",
+            ]
         # Add user-specified overlays.
-        for item in args.overlay_rwdir:
-            self.virtme_param["overlay_rwdir"] += " --overlay-rwdir " + item
+        dirs += args.overlay_rwdir
+        # De-duplicate
+        dirs = list(dict.fromkeys(dirs))
+        self.virtme_param["overlay_rwdir"] = " ".join(
+            f"--overlay-rwdir {d}" for d in dirs
+        )
 
     def _get_virtme_run(self, args):
         if args.run is not None:


### PR DESCRIPTION
Do not drop /tmp from the default overlays when --rw is used.
This keeps /tmp writable via overlay and avoids unprivileged write
failures on external root filesystems (for example `apt` on 9p).


Before this patch:
```
$ unshare --map-root-user --map-auto --mount -- ./vng --network user --run ./kbuild/ --user root --root /roots/trixie --rw --force-9p -- "findmnt -T /tmp; ls -ld /tmp; su -s /bin/sh _apt -c 'touch /tmp/test.apt'; touch /tmp/test.root; ls -l /tmp/test*; rm /tmp/test*"
TARGET SOURCE    FSTYPE OPTIONS
/      /dev/root 9p     rw,relatime,access=any,msize=512000,trans=virtio
drwxrwxrwt 6 root root 163 Mar  4  2026 /tmp
touch: setting times of '/tmp/test.apt': Permission denied
-rw-r--r-- 1 root nogroup 0 Mar  4  2026 /tmp/test.apt
-rw-r--r-- 1 root root    0 Mar  4  2026 /tmp/test.root
```
After:
```
$ unshare --map-root-user --map-auto --mount -- ./vng --network user --run ./kbuild/ --user root --root /roots/trixie --force-9p --rw -- "findmnt -T /tmp; ls -ld /tmp; su -s /bin/sh _apt -c 'touch /tmp/test.apt'; touch /tmp/test.root; ls -l /tmp/test*; rm /tmp/test*"
TARGET SOURCE             FSTYPE  OPTIONS
/tmp   virtme_rw_overlay0 overlay rw,relatime,lowerdir=/tmp,upperdir=/run/tmp/virtme_rw_overlay0/upper,workdir=/run/tmp/virtme_rw_overlay0/work,uuid=on
drwxrwxrwt 1 root root 60 Mar  4 18:02 /tmp
-rw-r--r-- 1 _apt nogroup 0 Mar  4 18:02 /tmp/test.apt
-rw-r--r-- 1 root root    0 Mar  4 18:02 /tmp/test.root
```