### PR TITLE
commands: run: Add systemd.hostname when --systemd is used

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1264,6 +1264,8 @@ def do_it() -> int:
     if args.name:
         qemuargs.extend(["-name", args.name])
         kernelargs.append(f"virtme_hostname={args.name}")
+        if args.systemd:
+            kernelargs.append(f"systemd.hostname={args.name}")
 
     if args.memory:
         # If no memory suffix is specified, assume it's MB.


### PR DESCRIPTION
When running vng with a script, sometimes I can observe systemd setting the hostname to localhost, later on virtme_ng_init set's the hostname, but /proc/sys/kernel/hostname still shows "localhost".

Ensure that both the vng-init and systemd have the same value when --systemd is required.