### PR TITLE
virtme-ng-init: Drop uzers dependency

### DIFF
--- a/virtme_ng_init/Cargo.lock
+++ b/virtme_ng_init/Cargo.lock
@@ -33,12 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "log"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,20 +45,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "uzers"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "virtme-ng-init"
 version = "0.1.0"
 dependencies = [
  "base64",
  "nix",
- "uzers",
 ]

--- a/virtme_ng_init/Cargo.toml
+++ b/virtme_ng_init/Cargo.toml
@@ -19,5 +19,4 @@ unused_qualifications = "warn"
 
 [dependencies]
 nix = { version = "0.29", features = ["feature", "fs", "hostname", "mount", "reboot", "user"] }
-uzers = "0.12"
 base64 = "0.22"

--- a/virtme_ng_init/src/utils.rs
+++ b/virtme_ng_init/src/utils.rs
@@ -10,11 +10,10 @@ use nix::unistd::{chown, Gid, Uid};
 use std::ffi::{CString, OsStr};
 use std::fmt::Arguments;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::os::unix::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Stdio};
-use uzers::get_user_by_name;
 
 macro_rules! log {
     ($($arg:tt)*) => {
@@ -54,7 +53,16 @@ pub fn log_impl(msg: Arguments<'_>) {
 }
 
 pub fn get_user_id(username: &str) -> Option<u32> {
-    Some(get_user_by_name(username)?.uid())
+    let file = File::open("/etc/passwd").ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().map_while(Result::ok) {
+        let parts: Vec<&str> = line.split(':').collect();
+        if parts.len() >= 3 && parts[0] == username {
+            return parts[2].parse::<u32>().ok();
+        }
+    }
+    None
 }
 
 pub fn do_chown(path: &str, uid: u32, gid: Option<u32>) -> io::Result<()> {


### PR DESCRIPTION
The uzers crate appears to have issues in minimal rootfs environments and can even trigger crashes such as:
```
  traps: virtme-ng-init[1] trap divide error ip:7f50f1a4e503 sp:7fffc8187220 error:0 in libc.so.6[185503,7f50f18f1000+188000]
  Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000008
```
Drop this dependency and implement get_user_id() using a simple and more reliable /etc/passwd parser.