### PR TITLE
virtme-ng: init: Fallback to "root" if specified user does not exist

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -689,7 +689,11 @@ setup_user_session() {
     local uid consdev
 
     if [[ -n ${virtme_user:-} ]]; then
-        uid="$(id -u -- "${virtme_user}")"
+        if ! uid="$(id -u -- "${virtme_user}" 2> /dev/null)"; then
+            log "user '${virtme_user}' not found in guest, falling back to root"
+            unset -v virtme_user
+            uid=0
+        fi
     else
         uid="$(id -u)"
     fi

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -1138,10 +1138,17 @@ fn run_user_session(consdev: &str, uid: u32) {
 }
 
 fn setup_user_session() {
-    let uid = env::var("virtme_user")
-        .ok()
-        .and_then(|user| utils::get_user_id(&user))
-        .unwrap_or(0);
+    let uid = match env::var("virtme_user") {
+        Ok(ref user) => match utils::get_user_id(user) {
+            Some(id) => id,
+            None => {
+                log!("user '{}' not found in guest, falling back to root", user);
+                env::remove_var("virtme_user");
+                0
+            }
+        },
+        Err(_) => 0,
+    };
 
     let consdev = if let Some(console) = get_active_console() {
         console


### PR DESCRIPTION
If virtme_user is specified but the user does not exist in the guest environment, the initialization scripts currently fail when attempting to resolve the UID.

Handle this case by falling back to root instead of exiting.