### PR TITLE
virtme: Fix shell handling for guest session

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1924,8 +1924,7 @@ def do_it() -> int:
     if args.user and args.user != "root":
         kernelargs.append(f"virtme_user={args.user}")
 
-    # Pass shell for guest only when --shell is explicitly set, otherwise
-    # init uses /bin/sh.
+    # Pass shell only when --shell is set, otherwise use user's default shell.
     if args.shell is not None:
         kernelargs.append(f"virtme_shell={args.shell}")
 

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -652,18 +652,31 @@ run_user_gui() {
 }
 
 run_user_shell() {
-    local consdev=$1 uid=$2
+    local consdev=$1 uid=$2 session_shell
 
     print_logo
 
-    if [[ -n ${virtme_user:-} ]]; then
-        shell=""
-        if [[ -n ${virtme_shell:-} ]]; then
-            shell="-s ${virtme_shell}"
-        fi
-        setsid bash -c "su ${shell} -- ${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
+    # If virtme_shell is set use it, otherwise use the shell defined in /etc/passwd.
+    if [[ -n ${virtme_shell:-} ]]; then
+        session_shell=$(command -v "${virtme_shell}" 2> /dev/null)
+        [[ -z "$session_shell" || ! -x "$session_shell" ]] && session_shell=$(getent passwd "${virtme_user:-root}" 2> /dev/null | cut -d: -f7)
+        [[ -z "$session_shell" || ! -x "$session_shell" ]] && session_shell=/bin/sh
     else
-        setsid bash 0<> "/dev/$consdev" 1>&0 2>&0
+        session_shell=$(getent passwd "${virtme_user:-root}" 2> /dev/null | cut -d: -f7)
+        [[ -z "$session_shell" || ! -x "$session_shell" ]] && session_shell=/bin/sh
+    fi
+
+    if [[ -n ${virtme_user:-} ]]; then
+        export session_shell virtme_user
+        if [[ -n ${virtme_shell:-} ]]; then
+            # shellcheck disable=SC2016
+            setsid sh -c 'su -s "$session_shell" -- "$virtme_user"' 0<> "/dev/$consdev" 1>&0 2>&0
+        else
+            # shellcheck disable=SC2016
+            setsid sh -c 'su -- "$virtme_user"' 0<> "/dev/$consdev" 1>&0 2>&0
+        fi
+    else
+        setsid "$session_shell" 0<> "/dev/$consdev" 1>&0 2>&0
     fi
 }
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -986,46 +986,52 @@ fn detach_from_terminal(tty_fd: libc::c_int) {
     }
 }
 
-/// Fallback when preferred shell (virtme_shell or host $SHELL) is not present in the guest.
+/// Use /bin/sh to launch commands, session shell is virtme_shell or user's default shell.
 const FALLBACK_SHELL: &str = "/bin/sh";
 
-/// Resolve the shell to use: virtme_shell (from --shell or host $SHELL) if it exists in the
-/// guest, otherwise /bin/sh so minimal rootfs work.
-fn resolve_shell() -> String {
+/// Resolve the path of a shell by name or path; returns None if not found or not a file.
+fn resolve_shell_path(preferred: &str) -> Option<String> {
     let path_env =
         env::var("PATH").unwrap_or_else(|_| "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin".into());
     let paths: Vec<&str> = path_env.split(':').collect();
 
-    let preferred = match env::var("virtme_shell") {
-        Ok(s) if !s.is_empty() => s,
-        _ => return FALLBACK_SHELL.to_string(),
-    };
-
     let resolved = if preferred.contains('/') {
-        let path = Path::new(&preferred);
+        let path = Path::new(preferred);
         if path.is_file() {
-            preferred
+            preferred.to_string()
         } else {
-            FALLBACK_SHELL.to_string()
+            return None;
         }
     } else {
-        let found = paths.iter().find_map(|dir| {
-            let candidate = Path::new(dir).join(&preferred);
+        paths.iter().find_map(|dir| {
+            let candidate = Path::new(dir).join(preferred);
             if candidate.is_file() {
                 Some(candidate.to_string_lossy().into_owned())
             } else {
                 None
             }
-        });
-        found.unwrap_or_else(|| FALLBACK_SHELL.to_string())
+        })?
     };
 
-    // Final safeguard: ensure the chosen path exists (e.g. FALLBACK_SHELL on minimal rootfs).
     if Path::new(&resolved).is_file() {
-        resolved
+        Some(resolved)
     } else {
-        FALLBACK_SHELL.to_string()
+        None
     }
+}
+
+/// Resolve virtme_shell if available, or use uid's default shell.
+fn resolve_session_shell(uid: u32) -> String {
+    if let Ok(s) = env::var("virtme_shell") {
+        if !s.is_empty() {
+            if let Some(resolved) = resolve_shell_path(&s) {
+                return resolved;
+            }
+        }
+    }
+    utils::get_shell_for_uid(uid)
+        .filter(|s| Path::new(s).is_file())
+        .unwrap_or_else(|| FALLBACK_SHELL.to_string())
 }
 
 fn run_shell(tty_fd: libc::c_int, shell: &str, args: &[&str]) {
@@ -1053,7 +1059,7 @@ fn run_shell(tty_fd: libc::c_int, shell: &str, args: &[&str]) {
     result.expect("Failed to start shell session");
 }
 
-fn run_user_gui(tty_fd: libc::c_int) {
+fn run_user_gui(tty_fd: libc::c_int, uid: u32) {
     // Generate a bare minimum xinitrc
     let xinitrc = "/run/tmp/.xinitrc";
 
@@ -1066,7 +1072,7 @@ fn run_user_gui(tty_fd: libc::c_int) {
             }
         }
     }
-    let shell = resolve_shell();
+    let shell = resolve_session_shell(uid);
     if let Err(err) = utils::create_file(
         xinitrc,
         0o0644,
@@ -1076,24 +1082,14 @@ fn run_user_gui(tty_fd: libc::c_int) {
         return;
     }
 
-    // Run graphical app using xinit directly
-    let mut args = vec!["-l", "-c"];
-    let storage;
-    if let Ok(user) = env::var("virtme_user") {
-        // Try to fix permissions on the virtual consoles, we are starting X
-        // directly here so we may need extra permissions on the tty devices.
+    let cmd = if let Ok(user) = env::var("virtme_user") {
         utils::run_cmd("/bin/sh", &["-c", &format!("chown {user} /dev/char/*")]);
-
-        // Clean up any previous X11 state.
         utils::run_cmd("/bin/sh", &["-c", "rm -f /tmp/.X11*/* /tmp/.X11-lock"]);
-
-        // Start xinit directly.
-        storage = format!("su -c 'xinit /run/tmp/.xinitrc' -- {user}");
-        args.push(&storage);
+        format!("su -c 'xinit /run/tmp/.xinitrc' -- {user}")
     } else {
-        args.push("xinit /run/tmp/.xinitrc");
-    }
-    run_shell(tty_fd, &shell, &args);
+        "xinit /run/tmp/.xinitrc".to_string()
+    };
+    run_shell(tty_fd, FALLBACK_SHELL, &["-c", &cmd]);
 }
 
 fn init_xdg_runtime_dir(uid: u32) {
@@ -1106,18 +1102,23 @@ fn init_xdg_runtime_dir(uid: u32) {
 }
 
 fn run_user_shell(tty_fd: libc::c_int) {
-    let shell = resolve_shell();
-    let mut args = vec![];
-    let cmd;
+    let target_uid = env::var("virtme_user")
+        .ok()
+        .and_then(|u| utils::get_user_id(&u))
+        .unwrap_or(0);
+    let session_shell = resolve_session_shell(target_uid);
+    print_logo();
 
     if let Ok(user) = env::var("virtme_user") {
-        cmd = format!("su -s {} -- {}", shell, user);
-        args.push("-c");
-        args.push(&cmd);
+        let cmd = if env::var("virtme_shell").is_ok() {
+            format!("su -s {} -- {}", session_shell, user)
+        } else {
+            format!("su -- {}", user)
+        };
+        run_shell(tty_fd, FALLBACK_SHELL, &["-c", &cmd]);
+    } else {
+        run_shell(tty_fd, &session_shell, &[]);
     }
-
-    print_logo();
-    run_shell(tty_fd, &shell, &args);
 }
 
 fn run_user_session(consdev: &str, uid: u32) {
@@ -1131,7 +1132,7 @@ fn run_user_session(consdev: &str, uid: u32) {
     }
 
     if env::var("virtme_graphics").is_ok() {
-        run_user_gui(tty_fd);
+        run_user_gui(tty_fd, uid);
     } else {
         run_user_shell(tty_fd);
     }
@@ -1154,7 +1155,7 @@ fn setup_user_session() {
         console
     } else {
         log!("failed to determine console");
-        let shell = resolve_shell();
+        let shell = resolve_session_shell(uid);
         let err = Command::new(&shell).arg("-l").exec();
         log!("failed to exec shell: {}", err);
         return;

--- a/virtme_ng_init/src/utils.rs
+++ b/virtme_ng_init/src/utils.rs
@@ -65,6 +65,28 @@ pub fn get_user_id(username: &str) -> Option<u32> {
     None
 }
 
+/// Return the login shell for the given uid from /etc/passwd, if present and usable.
+pub fn get_shell_for_uid(uid: u32) -> Option<String> {
+    let file = File::open("/etc/passwd").ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().map_while(Result::ok) {
+        let parts: Vec<&str> = line.split(':').collect();
+        if parts.len() >= 7 {
+            if let Ok(entry_uid) = parts[2].parse::<u32>() {
+                if entry_uid == uid {
+                    let shell = parts[6].trim();
+                    if !shell.is_empty() && shell != "/bin/false" && shell != "/usr/sbin/nologin" {
+                        return Some(shell.to_string());
+                    }
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}
+
 pub fn do_chown(path: &str, uid: u32, gid: Option<u32>) -> io::Result<()> {
     let gid_option = gid.map(Gid::from_raw);
 


### PR DESCRIPTION
Use the following logic to determine the shell to use on the guest:
  - always use /bin/sh to launch commands from virtme-ng-init/virtme-init
  - when starting the user session use --shell SHELL (if specified)
  - otherwise use the user's default shell (defined in /etc/passwd)

Fixes: c95b62d ("virtme: Improve shell handling and support minimal rootfs")