### PR TITLE
virtme-ng: Fix vCPU pinning

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1319,7 +1319,8 @@ class KernelSource:
             self.virtme_param["gdb"] = ""
 
     def _get_virtme_qmp(self, args):
-        if args.debug:
+        # QMP is needed for --debug (GDB/monitor) and for --pin (query-cpus-fast).
+        if args.debug or args.pin:
             self.virtme_param["qmp"] = "--qmp"
         else:
             self.virtme_param["qmp"] = ""


### PR DESCRIPTION
Using --pin without --debug triggers the following warning, breaking vCPU pinning:
```
  QMP connection failed after 5 attempts
  WARNING: Failed to pin vCPUs
```
The reason is that without --debug, QMP protocol isn't enabled and vng isn't able to determine the PIDs of the vCPUS.

Implicitly enable QMP when --pin is used.

Fixes: 8665b2b ("qmp: move option handling from vng to virtme")