### PR TITLE
s390x: cap default vCPU count

### DIFF
--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -665,6 +665,7 @@ ARCH_MAPPING = {
         "cross_compile": "s390x-linux-gnu-",
         "kernel_target": "bzImage",
         "kernel_image": "bzImage",
+        "max-cpus": 8,
     },
     "riscv64": {
         "qemu_name": "riscv64",


### PR DESCRIPTION
Non-native s390x boots under QEMU TCG can stall badly when virtme-ng forwards the host CPU count directly to the guest.

Set a conservative default cap of 8 vCPUs for s390x so the guest still gets some parallelism without hitting the RCU stalls and boot hangs seen with much larger SMP sizes.