### PR TITLE
ppc64le: fix pseries guest defaults

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -335,9 +335,17 @@ class Arch_ppc(Arch):
         return ret
 
     @staticmethod
+    def serial_console_args():
+        return ["hvc0"]
+
+    @staticmethod
     def config_base():
         return [
+            "CONFIG_PPC64=y",
             "CONFIG_CPU_LITTLE_ENDIAN=y",
+            "CONFIG_ALTIVEC=y",
+            "CONFIG_VSX=y",
+            "CONFIG_HVC_CONSOLE=y",
             "CONFIG_PPC_POWERNV=n",
             "CONFIG_PPC_SUBPAGE_PROT=y",
             "CONFIG_KVM_BOOK3S_64=y",


### PR DESCRIPTION
Teach the pseries defaults about the console and CPU features that modern ppc64le guests expect.

Use hvc0 as the guest serial console, and enable PPC64, ALTIVEC, VSX, and HVC_CONSOLE in the base config. This makes Tumbleweed userspace boot cleanly and restores a usable interactive console on ppc64le guests.