### PR TITLE
virtme-init: re-use bash to run su

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -659,7 +659,7 @@ run_user_shell() {
 
     [[ -n ${virtme_shell:-} ]] && args+=(-s "$virtme_shell")
     [[ -n ${virtme_user:-} ]] && args+=(-- "$virtme_user")
-    setsid su "${args[@]}" 0<> "/dev/$consdev" 1>&0 2>&0
+    setsid bash -c "su ${args[*]}" 0<> "/dev/$consdev" 1>&0 2>&0
 }
 
 run_user_session() {


### PR DESCRIPTION
Without this, such warning is visible:

    $ ./vng -r --shell /bin/bash --no-virtme-ng-init
    (...)
    bash: cannot set terminal process group (1184): Inappropriate ioctl for device
    bash: no job control in this shell

I didn't investigate why, but re-using bash here shouldn't be an issue.

Fixes: 94beb9b ("virtme-init: Always run su for user shell")