### PR TITLE
virtme-init: run user script before console setup

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -665,13 +665,6 @@ run_user_shell() {
 run_user_session() {
     local consdev=$1 uid=$2
 
-    setup_user_script "$uid"
-
-    # Script mode but script I/O ports were missing; run script on console and exit.
-    if [[ -n "${script_ports_missing:-}" ]]; then
-        run_user_script_on_console "$consdev" "$uid"
-    fi
-
     if [[ -n ${virtme_graphics:-} ]]; then
         run_user_gui "$consdev" "$uid"
         # Drop to console if the graphical app failed.
@@ -693,15 +686,23 @@ setup_user_session() {
         uid="$(id -u)"
     fi
 
+    init_xdg_runtime_dir "$uid"
+    setup_root_home
+
+    setup_user_script "$uid"
+
     get_active_console consdev
     if [[ -z $consdev ]]; then
         log "failed to determine console"
         exec bash --login # At least try to be helpful
     fi
 
+    # Script mode but script I/O ports were missing; run script on console and exit.
+    if [[ -n "${script_ports_missing:-}" ]]; then
+        run_user_script_on_console "$consdev" "$uid"
+    fi
+
     configure_terminal "$consdev" "$uid"
-    init_xdg_runtime_dir "$uid"
-    setup_root_home
 
     log "initialization done"
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -1068,15 +1068,10 @@ fn run_user_shell(tty_fd: libc::c_int) {
     run_shell(tty_fd, "su", &args);
 }
 
-fn run_user_session(consdev: &str, uid: u32) {
+fn run_user_session(consdev: &str) {
     let flags = OFlag::O_RDWR | OFlag::O_NONBLOCK;
     let mode = Mode::empty();
     let tty_fd = open(consdev, flags, mode).expect("failed to open console");
-
-    if setup_user_script(uid) {
-        // Script mode but script I/O ports were missing; run script on console and exit.
-        run_user_script_on_console(consdev, uid);
-    }
 
     if env::var("virtme_graphics").is_ok() {
         run_user_gui(tty_fd);
@@ -1098,6 +1093,9 @@ fn setup_user_session() {
         Err(_) => 0,
     };
 
+    init_xdg_runtime_dir(uid);
+    setup_root_home();
+
     let consdev = if let Some(console) = get_active_console() {
         console
     } else {
@@ -1106,13 +1104,17 @@ fn setup_user_session() {
         log!("failed to exec /bin/sh: {}", err);
         return;
     };
+
+    if setup_user_script(uid) {
+        // Script mode but script I/O ports were missing; run script on console and exit.
+        run_user_script_on_console(consdev.as_str(), uid);
+    }
+
     configure_terminal(consdev.as_str(), uid);
-    init_xdg_runtime_dir(uid);
-    setup_root_home();
 
     log!("initialization done");
 
-    run_user_session(consdev.as_str(), uid);
+    run_user_session(consdev.as_str());
 }
 
 fn run_sshd() {


### PR DESCRIPTION
virtme-init breaks if the expected console device is not present in the system. This was observed while experimenting with external root filesystems. In that case, `--exec` should still work when the virtio-serial script ports are available.

Run the user script setup before console handling, and keep the existing console fallback only for cases where the script I/O ports are unavailable.

---

Logs:
```
vng -vr --append virtme_console=ttyNOPE --exec 'echo hello world'

(...)
thread 'main' (1) panicked at src/main.rs:941:10:
Faile[ d    1t.o7 9o8p6e56][    T1] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00006500
n[  c o n s1o.l7e9 9d4e6v6i]c[e    T1] CPU: 4 UID: 0 PID: 1 Comm: virtme-ng-init Not tainted 6.18.16-1-longterm #1 PREEMPT(voluntary) openSUSE Tumbleweed  0971f8ae13624fc6514268c7a003dfe25e9c30f0
[    1.800879][    T1] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[:   O s  1{. 8c0o1d4e8:1 ]2[,     T1] Call Trace:
[    1.801885][    T1]  <TASK>
kin[d :   N o1t.F8o0u2n1d6,0 ][    T1]  dump_stack_lvl+0x5b/0x80
me[s s a g e1:. 8"0N2o6 1s3u]c[    T1]  vpanic+0xdb/0x2e0
[    1.802980][    T1]  panic+0x5b/0x5b
h [f i l e  1o.r8 0d3i3r2e4c]t[    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.803840][    T1]  do_exit.cold+0x58/0x58
 ry["   }
1n.o8t0e4:2 3r6u][    T1]  do_group_exit+0x2d/0xc0
n [w i t h  1`.R8U0S4T7_2B8A]C[    T1]  __x64_sys_exit_group+0x18/0x20
[    1.805192][    T1]  x64_sys_call+0x14fa/0x1500
KT[R A C E =11.`8 0e5n6v3i2r]o[    T1]  do_syscall_64+0x81/0x800
[    1.806150][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
nm[e n t   v1a.r8i0a6b7l2e2 ]t[    T1]  ? __handle_mm_fault+0x8b8/0xf00
[    1.807270][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
o [d i s p l1a.y8 0a7 8b3a3c]k[    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.808414][    T1]  ? do_sigaltstack.constprop.0+0x133/0x190
 r[a c e
1.809013][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.809601][    T1]  ? __x64_sys_sigaltstack+0xc1/0xe0
[    1.810134][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.810697][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.811258][    T1]  ? do_syscall_64+0x81/0x800
[    1.811727][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.812291][    T1]  ? handle_mm_fault+0x1d7/0x2d0
[    1.812767][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.813277][    T1]  ? do_user_addr_fault+0x218/0x6a0
[    1.813755][    T1]  ? srso_alias_return_thunk+0x5/0xfbef5
[    1.814264][    T1]  ? exc_page_fault+0x69/0x170
[    1.814726][    T1]  entry_SYSCALL_64_after_hwframe+0x76/0x7e
[    1.815271][    T1] RIP: 0033:0x7feabed39248
[    1.815684][    T1] Code: cc cc 90 90 90 90 90 90 90 90 90 90 90 90 90 90 f3 0f 1e fa 90 90 48 c7 c6 c8 ff ff ff eb 04 0f 1f 00 f4 b8 e7 00 00 00 0f 05 <48> 3d 00 f0 ff ff 76 f0 f7 d8 64 89 06 eb e9 cc cc cc cc cc cc cc
[    1.817423][    T1] RSP: 002b:00007fff07ef21e8 EFLAGS: 00000202 ORIG_RAX: 00000000000000e7
[    1.818180][    T1] RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007feabed39248
[    1.818896][    T1] RDX: 0000555579c72748 RSI: ffffffffffffffc8 RDI: 0000000000000065
[    1.819610][    T1] RBP: 0000000000000065 R08: 0000000000000000 R09: 0000000000000000
[    1.820321][    T1] R10: 0000000000000000 R11: 0000000000000202 R12: 00007feabed98780
[    1.821035][    T1] R13: 00007feabecc09ae R14: 0000000000000001 R15: 00007feabed9abe0
[    1.821752][    T1]  </TASK>
[    1.822270][    T1] Kernel Offset: 0x18000000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
```

```
./vng -vr --append virtme_console=ttyNOPE --no-virtme-ng-init --exec 'echo hello world'

(...)
[    2.148448][    T1] virtme-init: udev is done
chown: cannot access '/dev/ttyNOPE': No such file or directory
[    2.199726][    T1] virtme-init: /dev/ttyNOPE doesn't exist.
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
tty: ttyname error: Inappropriate ioctl for device
virtme-ng:/mnt/ext/src/virt/virtme-ng/main #
```
