### PR TITLE
virtme/run: fix SIGTTOU hang when run from a background process group

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -2160,7 +2160,11 @@ def save_terminal_settings():
 
 def restore_terminal_settings(settings):
     if settings is not None:
-        termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, settings)
+        old = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        try:
+            termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, settings)
+        finally:
+            signal.signal(signal.SIGTTOU, old)
 
 
 def signal_handler(_signum, _frame):


### PR DESCRIPTION
When virtme-run exits from a background process group, restore_terminal_settings() calls tcsetattr() which triggers SIGTTOU. The default action for SIGTTOU is to stop the process, as seen in the manpage signal(7) table for default actions:

```
SIGTTOU      P1990      Stop    Terminal output for background process
```

If vng does not receive SIGCONT, it will be stopped forever and the caller may wait indefinitely.

This patch fixes this by temporarily ignoring SIGTTOU around the tcsetattr() call.  This lets the terminal restoration succeed regardless of whether virtme-run is in the foreground or background process group. The ignore is scoped so narrowly out of fear of accidentally leaking SIG_IGN of SIGTTOU to child processes (QEMU) unnecessarily.

Reproducer:

```
	$ cat test.sh
	#!/bin/bash
	set -m
	vng --run --dry-run &
	set +m
	wait $!
	echo "done: $?"

	$ ./test.sh
	# prints qemu and params, but hangs forever
```

Using strace, we can see:

```
[...]
2328  ioctl(0, TCSETSF2, {...})  = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
2328  --- SIGTTOU {si_signo=SIGTTOU, si_code=SI_KERNEL} ---
2328  --- stopped by SIGTTOU ---
```

... just prior to hang.

Verified with version:

	$ vng --version
	virtme-ng 1.40+150.g69bc00b3382c

	Python 3.12.13

The issue was discovered when trying to add vng --run --dry-run to a program called within Linux kernel's `make kselftest TARGETS=vsock`, which spins off the program as a background process.