### PR TITLE
virtme: configkernel: Allow to pass configs via stdin

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -6,11 +6,13 @@
 # 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643
 
 import argparse
+import io
 import multiprocessing
 import os
 import platform
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 
@@ -18,10 +20,36 @@ from .. import architectures
 from ..util import SilentError
 
 
-def check_file_arg(filepath):
-    if not os.path.isfile(filepath):
-        raise argparse.ArgumentTypeError(f"'{filepath}' is not a valid file.")
-    return filepath
+def is_readable(path: str) -> str:
+    """Validate path is a readable file (no directories or sockets)."""
+    try:
+        st = os.stat(path)
+    except OSError as error:
+        raise argparse.ArgumentTypeError(
+            f"'{path}' does not exist or is not accessible: {error}"
+        ) from error
+
+    if stat.S_ISDIR(st.st_mode):
+        raise argparse.ArgumentTypeError(f"'{path}' is a directory")
+
+    if stat.S_ISSOCK(st.st_mode):
+        raise argparse.ArgumentTypeError(f"'{path}' is a socket")
+
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    except OSError as error:
+        raise argparse.ArgumentTypeError(
+            f"'{path}' is not readable via os.open(): {error}"
+        ) from error
+    os.close(fd)
+    return path
+
+
+def check_file_arg(filepath: str) -> str:
+    """Accept a config file path or '-' for stdin."""
+    if filepath == "-":
+        return "-"
+    return is_readable(filepath)
 
 
 def make_parser():
@@ -49,7 +77,7 @@ def make_parser():
         action="append",
         type=check_file_arg,
         metavar="CUSTOM",
-        help="Use a custom config snippet file to override specific config options",
+        help="Use a custom config snippet file (or '-' for stdin) to override config",
     )
 
     parser.add_argument(
@@ -333,10 +361,16 @@ def do_it():
 
     # else we make a fresh config
     custom_conf = []
+    stdin_content = None
     if args.custom:
         for conf_chunk in args.custom:
-            with open(conf_chunk, encoding="utf-8") as fd:
-                custom_conf += fd.readlines()
+            if conf_chunk == "-":
+                if stdin_content is None:
+                    stdin_content = sys.stdin.read()
+                custom_conf += io.StringIO(stdin_content).readlines()
+            else:
+                with open(conf_chunk, encoding="utf-8") as fd:
+                    custom_conf += fd.readlines()
 
     if args.verbose:
         print(f"custom:\n{custom_conf}")

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -35,7 +35,7 @@ from virtme_ng.utils import get_conf, spinner_decorator
 from virtme_ng.version import VERSION
 
 
-def check_call_cmd(command, quiet=False, dry_run=False):
+def check_call_cmd(command, quiet=False, dry_run=False, pass_stdin=False):
     if dry_run:
         print(shlex.join(command))
         return
@@ -44,7 +44,7 @@ def check_call_cmd(command, quiet=False, dry_run=False):
         command,
         stdout=PIPE,
         stderr=PIPE,
-        stdin=DEVNULL,
+        stdin=None if pass_stdin else DEVNULL,
     ) as process:
         process.stdout.flush()
         process.stderr.flush()
@@ -244,8 +244,7 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "--custom",
         "-f",
         action="append",
-        help="Use one (or more) specific kernel .config snippet "
-        "to override default config settings",
+        help="Use one (or more) kernel .config snippet files, or '-' for stdin",
     )
 
     parser.add_argument(
@@ -777,6 +776,7 @@ class KernelSource:
             cmd,
             quiet=quiet,
             dry_run=args.dry_run and not configkernel_dry_run,
+            pass_stdin="-" in (args.config or []),
         )
 
     def _make_remote(self, args, make_command):


### PR DESCRIPTION
With the build command allow passing a config chunk via stdin and run commands like the following:
```
 $ cat << EOF | vng -vb --config /dev/stdin
 CONFIG_SCHED_DEBUG=y
 CONFIG_SCHED_AUTOGROUP=y
 CONFIG_SCHED_CORE=y
 CONFIG_SCHED_MC=y
 CONFIG_PREEMPT=y
 CONFIG_PREEMPT_DYNAMIC=y
 CONFIG_DEBUG_LOCKDEP=y
 EOF
```