### PR TITLE
Add support for repeated `--verbose` and demote `debug` to that

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -150,7 +150,10 @@ def make_parser() -> argparse.ArgumentParser:
         + "An argument can be optionally specified to start a graphical application.",
     )
     g.add_argument(
-        "--verbose", action="store_true", help="Increase console output verbosity."
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase console output verbosity.",
     )
     g.add_argument(
         "--net",

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -2125,8 +2125,10 @@ def do_it() -> int:
         )
         initrdpath = None
 
-    if args.verbose:
+    if args.verbose >= 2:
         kernelargs.append("debug")
+    elif args.verbose:
+        kernelargs.append("loglevel=7")
     else:
         kernelargs.append("quiet")
         kernelargs.append("loglevel=1")

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -451,7 +451,8 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     parser.add_argument(
         "--verbose",
         "-v",
-        action="store_true",
+        action="count",
+        default=0,
         help="Increase console output verbosity.",
     )
 
@@ -1228,7 +1229,9 @@ class KernelSource:
 
     def _get_virtme_verbose(self, args):
         if args.verbose:
-            self.virtme_param["verbose"] = "--verbose --show-boot-console"
+            self.virtme_param["verbose"] = " ".join(
+                ["--show-boot-console"] + ["--verbose"] * args.verbose
+            )
         else:
             self.virtme_param["verbose"] = ""
 


### PR DESCRIPTION
(This contains commits that were split off from #388)

THis makes two more changes that synergize with the `--fb` option:
- a single `--verbose` only enables `loglevel=7` and `--show-boot-console`
- a repeated `--verbose` is now required to also enable `debug`

This makes it easier to view the kernel boot log on the stdio console (as well as the early console log, which is also tied to `--verbose` elsewhere) without also suffering the effects of the `debug` cmdline option (which creates much more output and also potentially affects the userspace).