### PR TITLE
run: set `IdentitiesOnly yes` in the ssh client config

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1272,6 +1272,7 @@ def ssh_server(args, arch, qemuargs, kernelargs):
     CheckHostIP no
     User {username}
     IdentityFile {identity_file}
+    IdentitiesOnly yes
 
     # Disable all kinds of host identity checks, since these addresses are generally ephemeral.
     StrictHostKeyChecking no


### PR DESCRIPTION
This way, ssh will strictly use the specified IdentityFile, which is
the intended behavior (as a dedicated key is generated and injected
into both ssh server in the guest and ssh client on the host).

Otherwise, the agent takes precedence, potentially triggering hardware
tokens or other annoyances, if the user's main private key in the agent
is also added to their own `authorized_keys`.
