### PR TITLE
virtme_ng_init: better `sudoers` integration

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -313,7 +313,7 @@ generate_sudoers() {
         printf -- '%s ALL = (ALL) NOPASSWD: ALL\n' "${virtme_user}" >> "$tmpfile"
     fi
     chmod 440 "$tmpfile"
-    if [ ! -f "$real_sudoers" ]; then
+    if [[ ! -f $real_sudoers ]]; then
         touch "$real_sudoers"
     fi
     mount --bind "$tmpfile" "$real_sudoers"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -316,7 +316,9 @@ generate_sudoers() {
         real_sudoers=/etc/sudoers.d/99-virtme
     fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
-    echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
+    if [[ $real_sudoers == /etc/sudoers ]]; then
+        echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
+    fi
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"
     if [[ -n ${virtme_user:-} ]]; then
         printf -- '%s ALL = (ALL) NOPASSWD: ALL\n' "${virtme_user}" >> "$tmpfile"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -306,6 +306,15 @@ setup_network_lo() {
 generate_sudoers() {
     # Setup sudoers
     real_sudoers=/etc/sudoers
+    # if /etc/sudoers.d exists and is included from /etc/sudoers
+    # (and both are readable by the current user!),
+    # write a drop-in instead of overwriting /etc/sudoers
+    if [[ -f /etc/sudoers && -r /etc/sudoers ]] &&
+        [[ -d /etc/sudoers.d && -r /etc/sudoers.d ]] &&
+        ! find /etc/sudoers.d -maxdepth 1 -type f -not -readable -quit &&
+        grep -q -Fx '@includedir /etc/sudoers.d' /etc/sudoers; then
+        real_sudoers=/etc/sudoers.d/99-virtme
+    fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
     echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -306,9 +306,6 @@ setup_network_lo() {
 generate_sudoers() {
     # Setup sudoers
     real_sudoers=/etc/sudoers
-    if [ ! -e ${real_sudoers} ]; then
-        touch ${real_sudoers}
-    fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
     echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -316,7 +316,10 @@ generate_sudoers() {
         real_sudoers=/etc/sudoers.d/99-virtme
     fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
-    echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
+    if [[ $real_sudoers == /etc/sudoers ]]; then
+        # Only set a conservative default $PATH if writing a full sudoers
+        echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
+    fi
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"
     if [[ -n ${virtme_user:-} ]]; then
         printf -- '%s ALL = (ALL) NOPASSWD: ALL\n' "${virtme_user}" >> "$tmpfile"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -373,9 +373,6 @@ setup_network_lo() {
 generate_sudoers() {
     # Setup sudoers
     real_sudoers=/etc/sudoers
-    if [ ! -e ${real_sudoers} ]; then
-        touch ${real_sudoers}
-    fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
     echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -383,7 +383,10 @@ generate_sudoers() {
         real_sudoers=/etc/sudoers.d/99-virtme
     fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
-    echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
+    if [[ $real_sudoers == /etc/sudoers ]]; then
+        # Only set a conservative default $PATH if writing a full sudoers
+        echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
+    fi
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"
     if [[ -n ${virtme_user:-} ]]; then
         printf -- '%s ALL = (ALL) NOPASSWD: ALL\n' "${virtme_user}" >> "$tmpfile"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -380,7 +380,7 @@ generate_sudoers() {
         printf -- '%s ALL = (ALL) NOPASSWD: ALL\n' "${virtme_user}" >> "$tmpfile"
     fi
     chmod 440 "$tmpfile"
-    if [ ! -f "$real_sudoers" ]; then
+    if [[ ! -f $real_sudoers ]]; then
         touch "$real_sudoers"
     fi
     mount --bind "$tmpfile" "$real_sudoers"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -373,6 +373,15 @@ setup_network_lo() {
 generate_sudoers() {
     # Setup sudoers
     real_sudoers=/etc/sudoers
+    # if /etc/sudoers.d exists and is included from /etc/sudoers
+    # (and both are readable by the current user!),
+    # write a drop-in instead of overwriting /etc/sudoers
+    if [[ -f /etc/sudoers && -r /etc/sudoers ]] &&
+        [[ -d /etc/sudoers.d && -r /etc/sudoers.d ]] &&
+        ! find /etc/sudoers.d -maxdepth 1 -type f -not -readable -quit &&
+        grep -q -Fx '@includedir /etc/sudoers.d' /etc/sudoers; then
+        real_sudoers=/etc/sudoers.d/99-virtme
+    fi
     tmpfile="$(mktemp --tmpdir=/run/tmp)"
     echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"' > "$tmpfile"
     echo "root ALL = (ALL) NOPASSWD: ALL" >> "$tmpfile"

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -23,7 +23,7 @@ use nix::sys::wait::wait;
 use nix::unistd::sethostname;
 use std::env;
 use std::fs::{File, OpenOptions};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::os::fd::{AsRawFd, IntoRawFd};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -366,11 +366,36 @@ fn generate_sudoers() -> io::Result<()> {
     if let Ok(user) = env::var("virtme_user") {
         content += &format!("{user} ALL = (ALL) NOPASSWD: ALL\n");
     }
-    if !Path::new("/etc/sudoers").exists() {
-        utils::create_file("/etc/sudoers", 0o0440, "").unwrap_or(());
+
+    let sudoers_d = Path::new("/etc/sudoers.d");
+    let sudoers = Path::new("/etc/sudoers");
+
+    let sudoers_includes_d = if sudoers.exists() {
+        let mut content = String::new();
+        File::open(sudoers)?.read_to_string(&mut content)?;
+        content
+            .split("\n")
+            .any(|line| line == "@includedir /etc/sudoers.d")
+    } else {
+        false
+    };
+
+    let path = if sudoers_includes_d && sudoers_d.exists() && sudoers_d.is_dir() {
+        &sudoers_d.join("99-virtme")
+    } else {
+        sudoers
+    };
+    if !path.exists() {
+        utils::create_file(path.to_str().unwrap(), 0o0440, "").unwrap_or(());
     }
     utils::create_file(fname, 0o0440, &content).ok();
-    utils::do_mount(fname, "/etc/sudoers", "", libc::MS_BIND as usize, "");
+    utils::do_mount(
+        fname,
+        path.to_str().unwrap(),
+        "",
+        libc::MS_BIND as usize,
+        "",
+    );
     Ok(())
 }
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -361,7 +361,7 @@ fn generate_shadow() -> io::Result<()> {
 
 fn generate_sudoers() -> io::Result<()> {
     let fname = "/run/tmp/sudoers";
-    let mut content = "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"\n".to_string();
+    let mut content = String::new();
     content += "root ALL = (ALL) NOPASSWD: ALL\n";
     if let Ok(user) = env::var("virtme_user") {
         content += &format!("{user} ALL = (ALL) NOPASSWD: ALL\n");
@@ -383,6 +383,7 @@ fn generate_sudoers() -> io::Result<()> {
     let path = if sudoers_includes_d && sudoers_d.exists() && sudoers_d.is_dir() {
         &sudoers_d.join("99-virtme")
     } else {
+        content += "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"\n";
         sudoers
     };
     if !path.exists() {

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -362,7 +362,7 @@ fn generate_shadow() -> io::Result<()> {
 
 fn generate_sudoers() -> io::Result<()> {
     let fname = "/run/tmp/sudoers";
-    let mut content = "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"\n".to_string();
+    let mut content = String::new();
     content += "root ALL = (ALL) NOPASSWD: ALL\n";
     if let Ok(user) = env::var("virtme_user") {
         content += &format!("{user} ALL = (ALL) NOPASSWD: ALL\n");
@@ -400,6 +400,9 @@ fn generate_sudoers() -> io::Result<()> {
     let path = if sudoers_includes_d && sudoers_d_readable {
         &sudoers_d.join("99-virtme")
     } else {
+        // Only set a conservative default $PATH if we are writing a full sudoers
+        // (if not, we assume it is already configured as intended)
+        content += "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"\n";
         sudoers
     };
     if !path.exists() {

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -20,6 +20,7 @@ use nix::sys::reboot;
 use nix::sys::stat::Mode;
 use nix::sys::utsname::uname;
 use nix::sys::wait::wait;
+use nix::unistd::{AccessFlags, access};
 use nix::unistd::sethostname;
 use std::env;
 use std::fs::{File, OpenOptions};
@@ -366,11 +367,52 @@ fn generate_sudoers() -> io::Result<()> {
     if let Ok(user) = env::var("virtme_user") {
         content += &format!("{user} ALL = (ALL) NOPASSWD: ALL\n");
     }
-    if !Path::new("/etc/sudoers").exists() {
-        utils::create_file("/etc/sudoers", 0o0440, "").unwrap_or(());
+
+    let sudoers_d = Path::new("/etc/sudoers.d");
+    let sudoers = Path::new("/etc/sudoers");
+
+    // Check if /etc/sudoers is readable by current user (as the VM runs unprivileged)
+    // and includes /etc/sudoers.d
+    let sudoers_includes_d = std::fs::read_to_string(sudoers)
+        .map(|content| {
+            content
+                .split("\n")
+                .any(|line| line == "@includedir /etc/sudoers.d")
+        })
+        .unwrap_or(false);
+
+    // Check if the contents of /etc/sudoers.d are readable by current user
+    let sudoers_d_readable = std::fs::read_dir(sudoers_d)
+        .map(|mut entries| {
+            entries.all(|entry| {
+                entry
+                    .map(|e| e.path())
+                    .and_then(|p|
+                        access(&p, AccessFlags::R_OK)
+                            .map_err(Into::into)
+                    )
+                    .is_ok()
+            })
+        })
+        .unwrap_or(false);
+
+    // If /etc/sudoers.d is usable, then create a drop-in instead of overwriting sudoers
+    let path = if sudoers_includes_d && sudoers_d_readable {
+        &sudoers_d.join("99-virtme")
+    } else {
+        sudoers
+    };
+    if !path.exists() {
+        utils::create_file(path.to_str().unwrap(), 0o0440, "").unwrap_or(());
     }
     utils::create_file(fname, 0o0440, &content).ok();
-    utils::do_mount(fname, "/etc/sudoers", "", libc::MS_BIND as usize, "");
+    utils::do_mount(
+        fname,
+        path.to_str().unwrap(),
+        "",
+        libc::MS_BIND as usize,
+        "",
+    );
     Ok(())
 }
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -21,6 +21,7 @@ use nix::sys::stat::Mode;
 use nix::sys::utsname::uname;
 use nix::sys::wait::wait;
 use nix::unistd::sethostname;
+use nix::unistd::{access, AccessFlags};
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
@@ -370,11 +371,49 @@ fn generate_sudoers() -> io::Result<()> {
     if let Ok(user) = env::var("virtme_user") {
         content += &format!("{user} ALL = (ALL) NOPASSWD: ALL\n");
     }
-    if !Path::new("/etc/sudoers").exists() {
-        utils::create_file("/etc/sudoers", 0o0440, "").unwrap_or(());
+
+    let sudoers_d = Path::new("/etc/sudoers.d");
+    let sudoers = Path::new("/etc/sudoers");
+
+    // Check if /etc/sudoers is readable by current user (as the VM runs unprivileged)
+    // and includes /etc/sudoers.d
+    let sudoers_includes_d = std::fs::read_to_string(sudoers)
+        .map(|content| {
+            content
+                .split("\n")
+                .any(|line| line == "@includedir /etc/sudoers.d")
+        })
+        .unwrap_or(false);
+
+    // Check if the contents of /etc/sudoers.d are readable by current user
+    let sudoers_d_readable = std::fs::read_dir(sudoers_d)
+        .map(|mut entries| {
+            entries.all(|entry| {
+                entry
+                    .map(|e| e.path())
+                    .and_then(|p| access(&p, AccessFlags::R_OK).map_err(Into::into))
+                    .is_ok()
+            })
+        })
+        .unwrap_or(false);
+
+    // If /etc/sudoers.d is usable, then create a drop-in instead of overwriting sudoers
+    let path = if sudoers_includes_d && sudoers_d_readable {
+        &sudoers_d.join("99-virtme")
+    } else {
+        sudoers
+    };
+    if !path.exists() {
+        utils::create_file(path.to_str().unwrap(), 0o0440, "").unwrap_or(());
     }
     utils::create_file(fname, 0o0440, &content).ok();
-    utils::do_mount(fname, "/etc/sudoers", "", libc::MS_BIND as usize, "");
+    utils::do_mount(
+        fname,
+        path.to_str().unwrap(),
+        "",
+        libc::MS_BIND as usize,
+        "",
+    );
     Ok(())
 }
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -366,7 +366,7 @@ fn generate_shadow() -> io::Result<()> {
 
 fn generate_sudoers() -> io::Result<()> {
     let fname = "/run/tmp/sudoers";
-    let mut content = "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"\n".to_string();
+    let mut content = String::new();
     content += "root ALL = (ALL) NOPASSWD: ALL\n";
     if let Ok(user) = env::var("virtme_user") {
         content += &format!("{user} ALL = (ALL) NOPASSWD: ALL\n");
@@ -401,6 +401,9 @@ fn generate_sudoers() -> io::Result<()> {
     let path = if sudoers_includes_d && sudoers_d_readable {
         &sudoers_d.join("99-virtme")
     } else {
+        // Only set a conservative default $PATH if we are writing a full sudoers
+        // (if not, we assume it is already configured as intended)
+        content += "Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin\"\n";
         sudoers
     };
     if !path.exists() {


### PR DESCRIPTION
This PR does two things in order to improve ergonomics around sudo usage within the virtme instance.

- **virtme_ng_init: install override into /etc/sudoers.d if supported**
  If `/etc/sudoers.d` exists and is included, write a drop-in instead of overriding the entire config. This way, we preserve the distro-specific or user-specific customizations that might have been done (e.g., the user might have added custom `Defaults env_keep` statements important to their workflow).

- **virtme_ng_init: do not override $PATH if adding a sudoers.d dropin**
  In the same vein, if we are writing a drop-in, do not provide a `Defaults secure_path` statement. Injecting a reasonable typical secure_path makes sense if we are writing a config from scratch, but if we are adding to a pre-existing config, it is fair to assume that the secure_path would already be set (or unset!) according to the user's expectations (e.g., the user might have elected to _not_ use a secure_path to access binaries importatnt to their workflow, and we should not override that decision).