### PR TITLE
tools: nix recipe to build a tool VM disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,18 @@ Examples
    $ vng --disk /tmp/disk.img
    ```
 
+ - Use a disk VM built using Nix as a package manager (example [here](tools))
+   and containing tools, e.g. to run the tests in a more reproducible way:
+
+   ```shell
+   # mkdir -p /nix/store
+   $ vng -r --disk nix-store.erofs.disk
+     > sudo mount /dev/vda /nix/store
+     > PATH="/nix/store/tools/bin:${PATH}"
+     > hello
+     Hello, world!
+   ```
+
  - Recompile the kernel passing some env variables to enable Rust support
    (using specific versions of the Rust toolchain binaries):
    ```shell

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,57 @@
+# Tools VM disk using Nix
+
+## Context
+
+By default, virtme-ng uses the host file-system, or the one from a rootfs.
+That's good for developers who already have all the tools required to launch
+some tests, but that can be an issue for new ones, or the ones who exceptionally
+need to execute some tests from other subsystems. While at it, this can also be
+useful for CIs and other developers, to have a more reproducible environment to
+execute these tests.
+
+This is an alternative to using containers or rootfs including a whole
+file-system, and being limited to what's in it, e.g. when a specific debugging
+tool is required: existing ones on the host cannot be used.
+
+## Description
+
+This will build an EROFS image, similar to [the one in Nixpkgs' `qemu-vm.nix`](https://github.com/NixOS/nixpkgs/blob/fed54261b0f4923235c9bb340b23ec1f4a1e2384/nixos/modules/virtualisation/qemu-vm.nix#L172-L200),
+but including a `--transform` to create `/nix/store/tools/` from
+`/nix/store/<some-hash>-tools/tools/`.
+
+- `package.nix` is where the actual recipe of the image build is, and where
+  new packages can be added.
+- `flake.{nix,lock}` is not really necessary, but that's a common way to pin
+  `nixpkgs` instead of using whatever is in `$NIX_PATH`.
+- `default.nix` is not really necessary, but it's a shim to support the
+  traditional `nix` commands (i.e. `nix-build`) instead of only the experimental
+  new commands (i.e. `nix build`).
+
+## Build
+
+[Nix](https://nixos.org/download/) is obviously required here. Then, from the
+parent directory, launch `nix build`:
+
+```console
+$ nix build --extra-experimental-features nix-command -f tools
+```
+
+`--extra-experimental-features` is needed to be able to use Flakes. Then the
+image can be converted to the QCOW2 format for QEMU, and compressed (`-c`):
+
+```console
+$ qemu-img convert -c -f raw -O qcow2 result/nix-store.erofs nix-store.erofs.disk
+```
+
+Note that the raw image can also be tested without the need of a VM, e.g.
+
+```console
+$ mkdir -p /tmp/vm/nix/store
+$ sudo modprobe erofs
+$ sudo mount -v result/nix-store.erofs /tmp/vm/nix/store
+$ sudo chroot /tmp/vm /nix/store/tools/bin/bash
+
+$ PATH=/nix/store/tools/bin
+$ hello
+Hello, world!
+```

--- a/tools/default.nix
+++ b/tools/default.nix
@@ -1,0 +1,19 @@
+# Boilerplate to support traditional (non-Flake) Nix
+let
+  flake-lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  flake-compat-node = flake-lock.nodes.root.inputs.flake-compat;
+  flake-compat = builtins.fetchTarball {
+    url =
+      flake-lock.nodes.${flake-compat-node}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${
+          flake-lock.nodes.${flake-compat-node}.locked.rev
+        }.tar.gz";
+    sha256 = flake-lock.nodes.${flake-compat-node}.locked.narHash;
+  };
+  flake = (
+    import flake-compat {
+      src = ./.;
+    }
+  );
+in
+flake.defaultNix // flake.outputs.packages.${builtins.currentSystem}

--- a/tools/flake.lock
+++ b/tools/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tools/flake.nix
+++ b/tools/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "virtme-ng tools";
+
+  nixConfig = {
+  };
+
+  inputs = {
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
+    # Use https://status.nixos.org to pick a working nixpkgs commit, eg:
+    # nix flake update nixpkgs --override-flake nixpkgs github:NixOS/nixpkgs/2c3e5ec5df46d3aeee2a1da0bfedd74e21f4bf3a --allow-dirty-locks
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs =
+    inputs:
+    let
+      inherit (inputs.nixpkgs) lib;
+      foreachSystem =
+        gen:
+        lib.genAttrs lib.systems.flakeExposed (
+          system:
+          gen {
+            inherit system;
+            pkgs = inputs.nixpkgs.legacyPackages.${system};
+          }
+        );
+    in
+    {
+      packages = foreachSystem (
+        { system, pkgs, ... }:
+        {
+          default = pkgs.callPackage ./package.nix { };
+        }
+      );
+    };
+}

--- a/tools/package.nix
+++ b/tools/package.nix
@@ -1,0 +1,68 @@
+# An EROFS (enhanced lightweight linux read-only filesystem)
+# for a Nix Store containing:
+# - the full dependency closure of packages listed in `passthru.packages`,
+# - a convenient `passthru.package` merging `bin/` directories of packages
+#   listed in `passthru.packages` in `${name}/`
+#   so that they can easily be accessed at `/nix/store/${name}/bin/` in the VM.
+{
+  bash,
+  buildEnv,
+  closureInfo,
+  emptyDirectory,
+  erofs-utils,
+  gnutar,
+  hello,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "tools";
+
+  passthru = {
+    filesystem = {
+      label = finalAttrs.name;
+      UUID = "22e210b6-ff78-440b-9038-2e30cbaf3f36";
+    };
+    packages = [
+      bash
+      hello
+    ];
+    package = buildEnv {
+      name = finalAttrs.name;
+      paths = finalAttrs.passthru.packages;
+      extraPrefix = "/${finalAttrs.name}";
+      pathsToLink = [
+        "/bin"
+      ];
+    };
+  };
+
+  src = emptyDirectory;
+
+  buildPhase = ''
+    mkdir -p "$out"
+    (
+    set -x
+    ${gnutar}/bin/tar --create \
+      --absolute-names \
+      --verbatim-files-from \
+      --transform 'flags=rSh;s|^${finalAttrs.passthru.package}/||' \
+      --transform 'flags=rSh;s|^/nix/store/||' \
+      --transform 'flags=rSh;s|~nix~case~hack~[[:digit:]]\+||g' \
+      --files-from ${
+        closureInfo {
+          rootPaths = [ finalAttrs.passthru.package ];
+        }
+      }/store-paths |
+    ${erofs-utils}/bin/mkfs.erofs \
+      --quiet \
+      --force-uid=0 \
+      --force-gid=0 \
+      -L ${finalAttrs.passthru.filesystem.label} \
+      -U ${finalAttrs.passthru.filesystem.UUID} \
+      -T 0 \
+      --hard-dereference \
+      --tar=f \
+      "$out"/nix-store.erofs
+    )
+  '';
+})


### PR DESCRIPTION
By default, virtme-ng uses the host file-system, or the one from a rootfs. That's good for developers who already have all the tools required to launch some tests, but that can be an issue for new ones, or the ones who exceptionally need to execute some tests from other subsystems. While at it, this can also be useful for CIs and other developers, to have a more reproducible environment to execute these tests.

This is an alternative to using containers or rootfs including a whole file-system, and being limited to what's in it, e.g. when a specific debugging tool is required: existing ones on the host cannot be used.

Please see the new README.md file to see how to build it. To use it once built:

```console
# mkdir -p /nix/store
$ vng -r --disk nix-store.erofs.disk
  > sudo mount /dev/vda /nix/store
  > PATH="/nix/store/tools/bin:${PATH}"
  > hello
  Hello, world!
```