### PR TITLE
README: disk: `virtio-blk` is used by `vng --disk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Examples
    $ vng --net user
    ```
 
- - Run the previously compiled kernel adding an additional virtio-scsi device:
+ - Run the previously compiled kernel adding an additional virtio-blk device:
    ```shell
    $ qemu-img create -f qcow2 /tmp/disk.img 8G
    $ vng --disk /tmp/disk.img


### PR DESCRIPTION
Which might be a bit confusing, because `virtio-scsi` is used by `virtme-run --disk`.