### PR TITLE
virtme-ng: Fix vCPU pinning QMP connect timing out

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -10,15 +10,18 @@ import atexit
 import errno
 import fcntl
 import itertools
+import json
 import os
 import platform
 import re
 import shlex
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
 import termios
+import threading
 from base64 import b64encode
 from pathlib import Path
 from shutil import which
@@ -139,6 +142,21 @@ def make_parser() -> "VirtmeArgumentParser":
         const=3636,
         metavar="PORT",
         help="Enable QMP (QEMU Machine Protocol) support on TCP",
+    )
+    g.add_argument(
+        "--pin",
+        "-P",
+        nargs="?",
+        const="all",
+        metavar="CPULIST",
+        help=(
+            "Pin each QEMU vCPU thread to a distinct host CPU. "
+            "If given without arguments, all host CPUs are used. "
+            "If given with an argument, it must be a list/range of CPUs "
+            "(e.g., 0,1,3-5,9). "
+            "NOTE: only a single guest can be pinned at a time, "
+            "pinning multiple guests is not supported yet."
+        ),
     )
     g.add_argument(
         "--graphics",
@@ -1805,6 +1823,11 @@ def do_it() -> int:
         qemuargs.extend(["-gdb", f"tcp:localhost:{args.gdb_server}"])
         kernelargs.extend(["-a", "nokaslr"])
 
+    # --pin requires QMP; auto-enable on the default port if the user didn't
+    # request one explicitly.
+    if args.pin and args.qmp is None:
+        args.qmp = 3636
+
     if args.qmp is not None:
         qemuargs.extend(["-qmp", f"tcp:localhost:{args.qmp},server,nowait"])
 
@@ -2238,6 +2261,8 @@ ExecStart="""
     if not args.dry_run:
         pid = os.fork()
         if pid:
+            if args.pin:
+                _spawn_pin_thread(args)
             try:
                 pid, status = os.waitpid(pid, 0)
                 ret = fetch_script_retcode()
@@ -2255,6 +2280,99 @@ ExecStart="""
         else:
             os.execv(qemu.qemubin, qemuargs)
     return 0
+
+
+def _parse_cpu_list(expr):
+    """Expand a CPU list expression, i.e., '0,1,3-5,9' into [0,1,3,4,5,9]."""
+    if not expr:
+        return []
+    cpus = []
+    for part in expr.split(","):
+        if "-" in part:
+            start, end = map(int, part.split("-", 1))
+            cpus.extend(range(start, end + 1))
+        else:
+            cpus.append(int(part))
+    return cpus
+
+
+def _pin_vcpus(pin_arg, qmp_port):
+    """Pin QEMU vCPU threads to host CPUs in order via QMP."""
+    # Attempt QMP connection to the guest (retry up to 5 times).
+    for attempt in range(5):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # TODO: support multiple guests. pylint: disable=W0511
+            sock.connect(("localhost", qmp_port))
+            sock_f = sock.makefile(encoding="utf-8")
+            break
+        except ConnectionRefusedError:
+            if attempt < 4:
+                sleep(1)
+            else:
+                sys.stderr.write("QMP connection failed after 5 attempts\n")
+                sys.exit(1)
+
+    # Read initial QMP greeting message.
+    data = sock_f.readline()
+    if not data:
+        sys.stderr.write("QMP connection failed\n")
+        sys.exit(1)
+    # Exit "QEMU capabilities negotiation mode".
+    sock.send(json.dumps({"execute": "qmp_capabilities"}).encode("utf-8"))
+    data = sock_f.readline()
+    if not data:
+        sys.stderr.write("QMP capabilities negotiation failed\n")
+        sys.exit(1)
+    if json.loads(data) != {"return": {}}:
+        sys.stderr.write(f"QMP capabilities negotiation failed:\n{data}\n")
+        sys.exit(1)
+    # Query the running vCPUs.
+    sock.send(json.dumps({"execute": "query-cpus-fast"}).encode("utf-8"))
+    data = sock_f.readline()
+    if not data:
+        sys.stderr.write("QMP query-cpus-fast failed\n")
+        sys.exit(1)
+    response = json.loads(data)
+    if "return" not in response:
+        sys.stderr.write(f"QMP query-cpus-fast failed:\n{data}\n")
+        sys.exit(1)
+    cpu_threads = [
+        (entry["cpu-index"], entry["thread-id"])
+        for entry in response["return"]
+        if "thread-id" in entry
+    ]
+    # Sort by vCPU index so vCPU0 -> first host CPU, vCPU1 -> second, ...
+    cpu_threads.sort(key=lambda x: x[0])
+
+    # Resolve the allowed host-CPU set.
+    if pin_arg == "all":
+        allowed_cpus = sorted(os.sched_getaffinity(0))
+    else:
+        allowed_cpus = _parse_cpu_list(pin_arg)
+        if not allowed_cpus:
+            raise RuntimeError("Invalid CPU list expression for --pin")
+
+    for (_, tid), cpu in zip(cpu_threads, itertools.cycle(allowed_cpus)):
+        try:
+            os.sched_setaffinity(tid, {cpu})
+        except PermissionError:
+            sys.stderr.write(f"Permission denied: cannot set affinity for TID {tid}\n")
+        except ProcessLookupError:
+            sys.stderr.write(f"TID {tid} does not exist\n")
+
+
+def _spawn_pin_thread(args):
+    """Spawn a thread that waits for QEMU and pins vCPUs."""
+
+    def worker():
+        try:
+            _pin_vcpus(args.pin, args.qmp)
+        except SystemExit:
+            sys.stderr.write("WARNING: Failed to pin vCPUs\n")
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
 
 
 def save_terminal_settings():

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -14,8 +14,6 @@ import signal
 import socket
 import sys
 import tempfile
-import threading
-import time
 from pathlib import Path
 from select import select
 from subprocess import (
@@ -1322,11 +1320,18 @@ class KernelSource:
             self.virtme_param["gdb"] = ""
 
     def _get_virtme_qmp(self, args):
-        # QMP is needed for --debug (GDB/monitor) and for --pin (query-cpus-fast).
-        if args.debug or args.pin:
+        # QMP is needed for --debug (GDB/monitor); --pin auto-enables QMP on
+        # the virtme-run side, so we don't need to force it here.
+        if args.debug:
             self.virtme_param["qmp"] = "--qmp"
         else:
             self.virtme_param["qmp"] = ""
+
+    def _get_virtme_pin(self, args):
+        if args.pin:
+            self.virtme_param["pin"] = f"--pin {shlex.quote(args.pin)}"
+        else:
+            self.virtme_param["pin"] = ""
 
     def _get_virtme_snaps(self, args):
         if args.snaps:
@@ -1424,6 +1429,7 @@ class KernelSource:
         self._get_virtme_balloon(args)
         self._get_virtme_gdb(args)
         self._get_virtme_qmp(args)
+        self._get_virtme_pin(args)
         self._get_virtme_snaps(args)
         self._get_virtme_empty_passwords(args)
         self._get_virtme_busybox(args)
@@ -1479,6 +1485,7 @@ class KernelSource:
             + f"{self.virtme_param['balloon']} "
             + f"{self.virtme_param['gdb']} "
             + f"{self.virtme_param['qmp']} "
+            + f"{self.virtme_param['pin']} "
             + f"{self.virtme_param['snaps']} "
             + f"{self.virtme_param['busybox']} "
             + f"{self.virtme_param['nvgpu']} "
@@ -1487,8 +1494,6 @@ class KernelSource:
             + f"{self.virtme_param['qemu_opts']} "
             # Important: qemu_opts has to be the last one
         )
-        if args.pin:
-            self.set_affinity(args)
         check_call(cmd, shell=True)
 
     def dump(self, args):
@@ -1562,114 +1567,6 @@ class KernelSource:
                 # "DUMP_COMPLETED", "data": {"result": {"total": 1073741824, "status": "completed", "completed":
                 # 1073741824}}}
                 break
-
-    def _parse_cpu_list(self, expr):
-        """Expand a CPU list expression, i.e., '0,1,3-5,9' into [0,1,3,4,5,9]."""
-        if not expr:
-            return []
-        cpus = []
-        for part in expr.split(","):
-            if "-" in part:
-                start, end = map(int, part.split("-", 1))
-                cpus.extend(range(start, end + 1))
-            else:
-                cpus.append(int(part))
-        return cpus
-
-    def pin_vcpus(self, args):
-        """Pin QEMU vCPU threads to host CPUs in order via QMP."""
-        # Attempt QMP connection to the guest (retry up to 5 times)
-        for attempt in range(5):
-            try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                # TODO: support multiple vng guests. pylint: disable=W0511
-                sock.connect(("localhost", 3636))
-                sock_f = sock.makefile(encoding="utf-8")
-                break
-            except ConnectionRefusedError:
-                if attempt < 4:
-                    time.sleep(1)
-                else:
-                    sys.stderr.write("QMP connection failed after 5 attempts\n")
-                    sys.exit(1)
-
-        # Read initial QMP greeting message.
-        data = sock_f.readline()
-        if not data:
-            sys.stderr.write("QMP connection failed\n")
-            sys.exit(1)
-
-        # Negotiate capabilities.
-        sock.send(json.dumps({"execute": "qmp_capabilities"}).encode("utf-8"))
-        data = sock_f.readline()
-        if not data:
-            sys.stderr.write("QMP capabilities negotiation failed\n")
-            sys.exit(1)
-        resp = json.loads(data)
-        if resp != {"return": {}}:
-            sys.stderr.write(f"QMP capabilities negotiation failed:\n{data}\n")
-            sys.exit(1)
-
-        # Query vCPUs.
-        sock.send(json.dumps({"execute": "query-cpus-fast"}).encode("utf-8"))
-        data = sock_f.readline()
-        if not data:
-            sys.stderr.write("QMP query-cpus-fast failed\n")
-            sys.exit(1)
-
-        resp = json.loads(data)
-        vcpu_tids = [cpu["thread-id"] for cpu in resp.get("return", [])]
-        if not vcpu_tids:
-            sys.stderr.write("No vCPU threads found\n")
-            sys.exit(1)
-
-        # Determine the subset of physical CPUs.
-        n_host_cpus = os.cpu_count()
-        if n_host_cpus is None:
-            sys.stderr.write("Unable to determine number of host CPUs\n")
-            sys.exit(1)
-
-        if args.pin == "all":
-            allowed_cpus = list(range(n_host_cpus))
-        else:
-            allowed_cpus = self._parse_cpu_list(args.pin)
-            if not allowed_cpus:
-                raise RuntimeError("Invalid CPU list expression for --pin")
-
-        # Santiy checks.
-        if len(allowed_cpus) > n_host_cpus:
-            sys.stderr.write(
-                f"WARNING: not enough host CPUs available ({n_host_cpus}) for {len(vcpu_tids)} vCPUs\n"
-            )
-            sys.exit(1)
-        if len(vcpu_tids) > len(allowed_cpus):
-            sys.stderr.write(
-                f"WARNING: not enough host CPUs allowed ({len(allowed_cpus)}) for {len(vcpu_tids)} vCPUs\n"
-            )
-            sys.exit(1)
-
-        # Pin to the physical CPUs.
-        for cpu, tid in zip(allowed_cpus, vcpu_tids, strict=False):
-            try:
-                os.sched_setaffinity(tid, {cpu})
-            except PermissionError:
-                sys.stderr.write(
-                    f"Permission denied: cannot set affinity for TID {tid}\n"
-                )
-            except ProcessLookupError:
-                sys.stderr.write(f"TID {tid} does not exist\n")
-
-    def set_affinity(self, args):
-        """Spawn a thread that waits for QEMU and pins vCPUs."""
-
-        def worker():
-            try:
-                self.pin_vcpus(args)
-            except SystemExit:
-                sys.stderr.write("WARNING: Failed to pin vCPUs\n")
-
-        t = threading.Thread(target=worker, daemon=True)
-        t.start()
 
     def clean(self, args):
         """Clean a local or remote git repository."""


### PR DESCRIPTION
When `vng --pin` is used together with `--mods=auto` (default), a separate thread is spawned that immediately begins retrying the QMP connection to the QEMU/KVM instance, with a budget of five retries performed once per second.

The underlying virtme-run script, however, runs virtme-prep-kdir-mods (install kmods in .virtme_mods + depmod) before launching the QEMU/KVM instance. On large module trees this preparation can easily exceed the 5-second window: the QMP socket isn't open yet and pinning fails with `WARNING: Failed to pin vCPUs`.

Rather than extending the QMP retry budget (which would also delay real failures), gate the QMP connection attempt on a deterministic filesystem signal: virtme-prep-kdir-mods deletes modules.dep at the start and depmod recreates it at the end; this is the same staleness signal that virtme/commands/run.py already uses to decide whether to refresh the .virtme_mods directory.

Fix this introducing _kmods_prep_will_run() that mirrors the conditions used by virtme-run to decide whether prep will actually run, and a waiter _wait_for_kmods_ready() that polls modules.dep until it exists and is at least as fresh as modules.order. The polling runs in the main thread so it snapshots the staleness state before virtme-run has a chance to delete modules.dep; the waiter runs in the affinity worker so the foreground subprocess isn't blocked.

When prep isn't going to run (--skip-modules, --kimg / args.run set, missing modules.order, etc.) the worker falls through to the existing QMP retry with no added latency.