### PR TITLE
virtiofsd: use `--cache` instead of the deprecated version

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -853,7 +853,7 @@ class VirtioFS:
         os.system(
             f"{virtiofsd_path} --syslog --no-announce-submounts {acl_opt}"
             + f"--socket-path {self.sock} --shared-dir {path} "
-            + f"--sandbox none -o cache={cache} {stderr} &"
+            + f"--sandbox none --cache {cache} {stderr} &"
         )
         max_attempts = 5
         check_duration = 0.1


### PR DESCRIPTION
I noticed this issue when looking at system logs:

    Use of deprecated option format '-o': Please specify options without it (e.g., '--cache auto' instead of '-o cache=auto')

The `--cache` option is available since [v1.0.0](https://gitlab.com/virtio-fs/virtiofsd/-/commit/0e73286762eb) (Dec 2021), and the warning has been added in [v1.2.0](https://gitlab.com/virtio-fs/virtiofsd/-/commit/8074419d0c71) (May 2022).