### PR TITLE
vng, run: use virtiofs for internal helper exports

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -879,22 +879,43 @@ class VirtioFSConfig:
         self,
         path: str,
         mount_tag: str,
-        guest_tools_path=None,
-        memory=None,
         rw=False,
         posix_acl=False,
     ):
         self.path = path
         self.mount_tag = mount_tag
-        self.guest_tools_path = guest_tools_path
-        self.memory = memory
         self.rw = rw
         self.posix_acl = posix_acl
+
+
+class VirtioFSState:
+    def __init__(self, guest_tools_path, memory=None, memory_configured=False):
+        self.guest_tools_path = guest_tools_path
+        self.memory = memory
+        self.memory_configured = memory_configured
+
+
+def ensure_virtiofs_memory(
+    arch: architectures.Arch,
+    qemuargs: list[str],
+    state: VirtioFSState,
+) -> None:
+    if state.memory_configured:
+        return
+
+    memory = state.memory if state.memory is not None else "128M"
+    qemuargs.extend(["-object", f"memory-backend-memfd,id=mem,size={memory},share=on"])
+    if arch.numa_support():
+        qemuargs.extend(["-numa", "node,memdev=mem"])
+    else:
+        qemuargs.extend(["-machine", "memory-backend=mem"])
+    state.memory_configured = True
 
 
 def export_virtiofs(
     arch: architectures.Arch,
     qemuargs: list[str],
+    state: VirtioFSState,
     config: VirtioFSConfig,
     verbose=False,
 ) -> bool:
@@ -904,7 +925,7 @@ def export_virtiofs(
     cache = "auto" if config.rw else "always"
 
     # Try to start virtiofsd daemon
-    virtio_fs = VirtioFS(config.guest_tools_path)
+    virtio_fs = VirtioFS(state.guest_tools_path)
     ret = virtio_fs.start(config.path, verbose, cache, config.posix_acl)
     if not ret:
         return False
@@ -918,16 +939,7 @@ def export_virtiofs(
         ["-device", f"{vhost_dev_type},chardev=char{fsid},tag={config.mount_tag}"]
     )
 
-    memory = config.memory if config.memory is not None else "128M"
-    if memory == 0:
-        return True
-
-    qemuargs.extend(["-object", f"memory-backend-memfd,id=mem,size={memory},share=on"])
-    if arch.numa_support():
-        qemuargs.extend(["-numa", "node,memdev=mem"])
-    else:
-        qemuargs.extend(["-machine", "memory-backend=mem"])
-
+    ensure_virtiofs_memory(arch, qemuargs, state)
     return True
 
 
@@ -1485,6 +1497,13 @@ def do_it() -> int:
     if args.force_9p:
         use_virtiofs = False
     else:
+        # When --numa is used, the memory backend is already configured by the
+        # user-provided NUMA layout.
+        virtiofs_state = VirtioFSState(
+            guest_tools_path,
+            memory=args.memory,
+            memory_configured=bool(args.numa),
+        )
         # Try to switch to 'microvm' on x86_64, but only if virtio-fs can be
         # used for now.
         if can_use_microvm(args):
@@ -1494,11 +1513,6 @@ def do_it() -> int:
         virtiofs_config = VirtioFSConfig(
             path=args.root,
             mount_tag="ROOTFS",
-            guest_tools_path=guest_tools_path,
-            # virtiofsd requires a NUMA not, if --numa is specified simply use
-            # the user-defined NUMA node, otherwise create a NUMA node with all
-            # the memory.
-            memory=0 if args.numa else args.memory,
             rw=args.rw,
             # Only enable POSIX ACLs when using an external root filesystem.
             # When sharing the host root (/), --posix-acl breaks UID/GID
@@ -1508,6 +1522,7 @@ def do_it() -> int:
         use_virtiofs = export_virtiofs(
             virt_arch,
             qemuargs,
+            virtiofs_state,
             virtiofs_config,
             verbose=args.verbose,
         )

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1226,7 +1226,9 @@ def console_client(args):
         os.execvp("socat", ["socat", socat_in, socat_out])
 
 
-def console_server(args, qemu, arch, qemuargs, kernelargs):
+def console_server(  # pylint: disable=R0917
+    args, qemu, arch, qemuargs, kernelargs, virtiofs_state
+):
     console_script_path = get_console_path(args.port)
     if os.path.exists(console_script_path):
         arg_fail(
@@ -1249,12 +1251,18 @@ def console_server(args, qemu, arch, qemuargs, kernelargs):
     else:
         console_exec = console_script_path
         if args.root != "/":
-            virtfs_config = VirtFSConfig(
+            vsockmount_fstype = export_hostfs(
+                qemu,
+                arch,
+                qemuargs,
+                virtiofs_state,
                 path=console_script_dir,
                 mount_tag="virtme.vsockmount",
+                verbose=args.verbose,
             )
-            export_virtfs(qemu, arch, qemuargs, virtfs_config)
             kernelargs.append(f"virtme_vsockmount={console_script_dir}")
+            kernelargs.append(f"virtme_vsockmount_fstype={vsockmount_fstype}")
+            kernelargs.append("virtme_vsockmount_access=ro")
 
     kernelargs.extend([f"virtme.vsockexec=`{console_exec}`"])
     qemuargs.extend(
@@ -1754,13 +1762,20 @@ def do_it() -> int:
         idx = mount_index
         mount_index += 1
         tag = f"virtme.initmount{idx}"
-        virtfs_config = VirtFSConfig(
+        readonly = dirtype != "rwdir"
+        fstype = export_hostfs(
+            qemu,
+            arch,
+            qemuargs,
+            virtiofs_state,
             path=hostpath,
             mount_tag=tag,
-            readonly=(dirtype != "rwdir"),
+            readonly=readonly,
+            verbose=args.verbose,
         )
-        export_virtfs(qemu, arch, qemuargs, virtfs_config)
         kernelargs.append(f"virtme_initmount{idx}={guestpath}")
+        kernelargs.append(f"virtme_initmount{idx}_fstype={fstype}")
+        kernelargs.append(f"virtme_initmount{idx}_access={'ro' if readonly else 'rw'}")
 
     for i, d in enumerate(args.overlay_rwdir):
         kernelargs.append(f"virtme_rw_overlay{i}={d}")
@@ -2149,7 +2164,7 @@ def do_it() -> int:
 
     if args.server is not None:
         if args.server == "console":
-            console_server(args, qemu, arch, qemuargs, kernelargs)
+            console_server(args, qemu, arch, qemuargs, kernelargs, virtiofs_state)
         elif args.server == "ssh":
             ssh_server(args, arch, qemuargs, kernelargs)
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -926,7 +926,12 @@ def export_virtiofs(
 
     # Try to start virtiofsd daemon
     virtio_fs = VirtioFS(state.guest_tools_path)
-    ret = virtio_fs.start(config.path, verbose, cache, config.posix_acl)
+    ret = virtio_fs.start(
+        config.path,
+        verbose,
+        cache,
+        config.posix_acl,
+    )
     if not ret:
         return False
 
@@ -980,6 +985,48 @@ def export_virtfs(
             ),
         ]
     )
+
+
+def export_hostfs(  # pylint: disable=R0917
+    qemu: qemu_helpers.Qemu,
+    arch: architectures.Arch,
+    qemuargs: list[str],
+    virtiofs_state: VirtioFSState | None,
+    path: str,
+    mount_tag: str,
+    readonly=True,
+    verbose=False,
+) -> str:
+    if virtiofs_state is not None:
+        virtiofs_config = VirtioFSConfig(
+            path=path,
+            mount_tag=mount_tag,
+            rw=not readonly,
+        )
+        if export_virtiofs(arch, qemuargs, virtiofs_state, virtiofs_config, verbose):
+            return "virtiofs"
+
+    virtfs_config = VirtFSConfig(
+        path=path,
+        mount_tag=mount_tag,
+        readonly=readonly,
+    )
+    export_virtfs(qemu, arch, qemuargs, virtfs_config)
+    return "9p"
+
+
+def hostfs_mount_cmd(fstype: str, access: str, mount_tag: str, mountpoint: str) -> str:
+    if fstype == "virtiofs":
+        return f"/bin/mount -n -t virtiofs -o {access} {mount_tag} {mountpoint}"
+
+    if fstype == "9p":
+        return (
+            f"/bin/mount -n -t 9p -o {access},"
+            "version=9p2000.L,trans=virtio,access=any,msize=524288 "
+            f"{mount_tag} {mountpoint}"
+        )
+
+    raise ValueError(f"unsupported hostfs type: {fstype}")
 
 
 def quote_karg(arg: str) -> str:
@@ -1494,6 +1541,7 @@ def do_it() -> int:
 
     # Try to use virtio-fs first, in case of failure fallback to 9p, unless 9p
     # is forced.
+    virtiofs_state = None
     if args.force_9p:
         use_virtiofs = False
     else:
@@ -1586,40 +1634,58 @@ def do_it() -> int:
             initcmds = [f"init={guest_tools_path}/{virtme_init_cmd}"]
     else:
         os.makedirs(CACHE_DIR, exist_ok=True)
-        virtfs_config = VirtFSConfig(
+        cache_fstype = export_hostfs(
+            qemu,
+            arch,
+            qemuargs,
+            virtiofs_state,
             path=str(CACHE_DIR),
             mount_tag="virtme.cache",
             readonly=False,
+            verbose=args.verbose,
         )
-        export_virtfs(qemu, arch, qemuargs, virtfs_config)
-        virtfs_config = VirtFSConfig(
+        guesttools_fstype = export_hostfs(
+            qemu,
+            arch,
+            qemuargs,
+            virtiofs_state,
             path=guest_tools_path,
             mount_tag="virtme.guesttools",
+            verbose=args.verbose,
         )
         fstab_path = get_conf("systemd.fstab")
-        export_virtfs(qemu, arch, qemuargs, virtfs_config)
         initsh = [
             "mount -t tmpfs run /run",
             "mkdir -p /run/virtme/cache",
-            "/bin/mount -n -t 9p -o rw,version=9p2000.L,trans=virtio,access=any,msize=524288 "
-            + "virtme.cache /run/virtme/cache",
+            hostfs_mount_cmd(cache_fstype, "rw", "virtme.cache", "/run/virtme/cache"),
             "mkdir -p /run/virtme/guesttools",
-            "/bin/mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any,msize=524288 "
-            + "virtme.guesttools /run/virtme/guesttools",
+            hostfs_mount_cmd(
+                guesttools_fstype,
+                "ro",
+                "virtme.guesttools",
+                "/run/virtme/guesttools",
+            ),
             f"mount --bind {fstab_path} /etc/fstab",
         ]
         if host_busybox is not None and busybox_guest_path is None:
-            export_virtfs(
+            busybox_fstype = export_hostfs(
                 qemu,
                 arch,
                 qemuargs,
-                VirtFSConfig(os.path.dirname(host_busybox), "virtme.busybox"),
+                virtiofs_state,
+                path=os.path.dirname(host_busybox),
+                mount_tag="virtme.busybox",
+                verbose=args.verbose,
             )
             initsh.extend(
                 [
                     "mkdir -p /run/virtme/busybox",
-                    "/bin/mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any,msize=524288 "
-                    + "virtme.busybox /run/virtme/busybox",
+                    hostfs_mount_cmd(
+                        busybox_fstype,
+                        "ro",
+                        "virtme.busybox",
+                        "/run/virtme/busybox",
+                    ),
                 ]
             )
             busybox_guest_path = os.path.join(

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -75,6 +75,26 @@ mount_virtme_overlays() {
     done
 }
 
+mount_hostfs() {
+    local fstype="$1"
+    local access="$2"
+    local source="$3"
+    local target="$4"
+
+    case "$fstype" in
+    virtiofs)
+        mount -t virtiofs -o "$access" "$source" "$target"
+        ;;
+    9p)
+        mount -t 9p -o version=9p2000.L,trans=virtio,access=any,msize=524288 "$source" "$target"
+        ;;
+    *)
+        log "unsupported hostfs type: $fstype"
+        return 1
+        ;;
+    esac
+}
+
 mount_kernel_modules() {
     local kver
 
@@ -196,11 +216,24 @@ generate_lvm() {
 }
 
 mount_virtme_initmounts() {
+    local access_var
+    local fstype_var
+    local suffix
+
     for tag in "${!virtme_initmount@}"; do
+        # Ignore per-mount metadata variables such as virtme_initmount0_fstype.
+        [[ $tag =~ ^virtme_initmount[0-9]+$ ]] || continue
+        suffix="${tag:16}"
         if [[ ! -d ${!tag} ]]; then
             mkdir -p "${!tag}"
         fi
-        mount -t 9p -o version=9p2000.L,trans=virtio,access=any,msize=524288 "virtme.initmount${tag:16}" "${!tag}" || exit 1
+        fstype_var="${tag}_fstype"
+        access_var="${tag}_access"
+        mount_hostfs \
+            "${!fstype_var:-9p}" \
+            "${!access_var:-rw}" \
+            "virtme.initmount${suffix}" \
+            "${!tag}" || exit 1
     done
 }
 
@@ -397,11 +430,16 @@ run_snapd() {
 }
 
 setup_socat_console() {
+    local access
+    local fstype
+
     vsock_exec=$(sed -ne "s/.*virtme.vsockexec=\`\(.*\)\`.*/\1/p" /proc/cmdline)
     if [[ -n ${vsock_exec} ]]; then
         if [[ -n ${virtme_vsockmount:-} ]]; then
             mkdir -p "${virtme_vsockmount}"
-            mount -t 9p -o version=9p2000.L,trans=virtio,access=any,msize=524288 "virtme.vsockmount" "${virtme_vsockmount}"
+            fstype="${virtme_vsockmount_fstype:-9p}"
+            access="${virtme_vsockmount_access:-ro}"
+            mount_hostfs "$fstype" "$access" virtme.vsockmount "${virtme_vsockmount}"
         fi
         socat "VSOCK-LISTEN:1024,reuseaddr,fork" \
             "EXEC:\"${vsock_exec}\",pty,stderr,setsid,sigint,sane,echo=0" &

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -536,17 +536,37 @@ fn mount_virtme_overlays() {
     }
 }
 
-fn mount_virtme_initmounts() {
-    for (key, path) in env::vars() {
-        if key.starts_with("virtme_initmount") {
-            utils::do_mkdir(&path);
+fn mount_hostfs(source: &str, target: &str, fstype: &str, access: &str) {
+    match fstype {
+        "virtiofs" => utils::do_mount(source, target, "virtiofs", 0, access),
+        "9p" => {
             utils::do_mount(
-                &key.replace('_', "."),
-                &path,
+                source,
+                target,
                 "9p",
                 0,
                 "version=9p2000.L,trans=virtio,access=any,msize=524288",
             );
+        }
+        _ => log!("unsupported hostfs type: {fstype}"),
+    }
+}
+
+fn mount_virtme_initmounts() {
+    for (key, path) in env::vars() {
+        if let Some(suffix) = key.strip_prefix("virtme_initmount") {
+            // Ignore per-mount metadata variables such as virtme_initmount0_fstype.
+            if !suffix.chars().all(|c| c.is_ascii_digit()) {
+                continue;
+            }
+
+            let fstype_key = format!("{key}_fstype");
+            let access_key = format!("{key}_access");
+            let fstype = env::var(fstype_key).unwrap_or_else(|_| "9p".to_string());
+            let access = env::var(access_key).unwrap_or_else(|_| "rw".to_string());
+
+            utils::do_mkdir(&path);
+            mount_hostfs(&key.replace('_', "."), &path, &fstype, &access);
         }
     }
 }
@@ -1223,14 +1243,13 @@ fn setup_socat_console() {
                 log!("setting up vsock proxy executing {}", exec);
                 let key = "virtme_vsockmount";
                 if let Ok(path) = env::var(key) {
+                    let fstype_key = format!("{key}_fstype");
+                    let access_key = format!("{key}_access");
+                    let fstype = env::var(fstype_key).unwrap_or_else(|_| "9p".to_string());
+                    let access = env::var(access_key).unwrap_or_else(|_| "ro".to_string());
+
                     utils::do_mkdir(&path);
-                    utils::do_mount(
-                        &key.replace('_', "."),
-                        &path,
-                        "9p",
-                        0,
-                        "version=9p2000.L,trans=virtio,access=any,msize=524288",
-                    );
+                    mount_hostfs(&key.replace('_', "."), &path, &fstype, &access);
                 }
 
                 let from = "VSOCK-LISTEN:1024,reuseaddr,fork";


### PR DESCRIPTION
While testing kernel modules in distro root filesystems with virtme-ng, I hit a boot failure with AlmaLinux/RHEL-style kernels: the rootfs itself could be exposed without 9p, but virtme-ng still tried to mount its guest tools through 9p before starting `virtme-init`.

Those kernels do not provide 9p support, so the guest panicked before userspace could run, even though the root filesystem transport was otherwise usable.

This PR adds an explicit `--root-guesttools[=PATH]` option for external-root users. It copies virtme’s guest tools into the rootfs and runs them from there, avoiding the extra 9p guesttools mount while leaving the current default behavior unchanged.