### PR TITLE
Spinner info

### DIFF
--- a/virtme_ng/spinner.py
+++ b/virtme_ng/spinner.py
@@ -1,9 +1,10 @@
-import os
 # -*- mode: python -*-
 # Copyright 2023 Andrea Righi
 
 """virtme-ng: UI spinner class."""
 
+import os
+import re
 import sys
 import threading
 import time
@@ -49,7 +50,15 @@ class Spinner:
     def __init__(self, message=""):
         self.message = message
         self.spin_info = os.environ.get("VNG_SPINNER_INFO", "")
-        self.spinner_str = "▁▂▃▄▅▆▇██▇▆▅▄▃▂▁"
+        self.spinner_width = 3
+        if self.spin_info:
+            m = re.match(r"^(\d+):(.*)$", self.spin_info)
+            if m:
+                self.spinner_width = int(m.group(1))
+                self.spin_info = m.group(2)
+        one_wave = "▁▂▃▄▅▆▇██▇▆▅▄▃▂▁"
+        repeats = self.spinner_width // len(one_wave) + 1
+        self.spinner_str = one_wave * repeats
         self.pos = 0
 
         self.stop_event = threading.Event()
@@ -102,7 +111,7 @@ class Spinner:
         spinner = self.spinner_str[self.pos :] + self.spinner_str[: self.pos]
         delta_t = int(time.time()) - self.start_time
         info = f" [{self.spin_info}]" if self.spin_info else ""
-        header = f"{spinner[:3]} {self.message}{info} ({delta_t} sec)\033[?25l"
+        header = f"{spinner[: self.spinner_width]} {self.message}{info} ({delta_t} sec)\033[?25l"
         spacer = f"\r{' ' * len(header)}\r"
 
         stdout = self.original_streams["stdout"]

--- a/virtme_ng/spinner.py
+++ b/virtme_ng/spinner.py
@@ -1,3 +1,4 @@
+import os
 # -*- mode: python -*-
 # Copyright 2023 Andrea Righi
 
@@ -47,6 +48,7 @@ class Spinner:
 
     def __init__(self, message=""):
         self.message = message
+        self.spin_info = os.environ.get("VNG_SPINNER_INFO", "")
         self.spinner_str = "▁▂▃▄▅▆▇██▇▆▅▄▃▂▁"
         self.pos = 0
 
@@ -99,7 +101,8 @@ class Spinner:
         self.pos = (self.pos + 1) % len(self.spinner_str)
         spinner = self.spinner_str[self.pos :] + self.spinner_str[: self.pos]
         delta_t = int(time.time()) - self.start_time
-        header = f"{spinner[:3]} {self.message} ({delta_t} sec)\033[?25l"
+        info = f" [{self.spin_info}]" if self.spin_info else ""
+        header = f"{spinner[:3]} {self.message}{info} ({delta_t} sec)\033[?25l"
         spacer = f"\r{' ' * len(header)}\r"
 
         stdout = self.original_streams["stdout"]


### PR DESCRIPTION
make vng's spinner display scriptable content, 
via envar: VNG_SPINNER_INFO

this lets a long-running multi-tree, multi-build batch build
provide custom info to the spinner, like work-tree, branch,
sha -dirty, config-name, config-sha etc.

vng then displays user info if user cares to add it.

while here, add a feature - if envar val matches ^\d+:.+$
the leading number is stripped and used to change the width.

$ VNG_SPINNER_INFO=20:foo vng -bv 
▅▆▇██▇▆▅▄▃▂▁▁▂▃▄ ⚙️c building kernel [foo] (1 sec)       
  DESCEND objtool                                       
  INSTALL libsubcmd_headers                             
▇▆▅▄▃▂▁▁▂▃▄▅▆▇██ ⚙️c building kernel [foo] (1 sec)       
Kernel: arch/x86/boot/bzImage is ready  (#85)           

the longer wave is vaguely pleasant to see from across the room.