### PR TITLE
Support running on a NixOS host

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,11 @@ Troubleshooting
    currently not shipping `virtme-ng-init` tool, which runs faster than the Bash
    init script, used as fallback.
 
+ - The guest helper scripts use a `#!/usr/bin/env bash` shebang, so the guest
+   root filesystem needs `/usr/bin/env`. This is present on virtually every
+   distribution, including minimal ones such as Alpine, but may be missing from
+   a hand-built `--root` chroot.
+
  - If you get permission denied when starting qemu, make sure that your
    username is assigned to the group `kvm` or `libvirt`:
    ```console

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -6,7 +6,8 @@
 # 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643
 
 configure_environment() {
-    export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+    local defaults=/run/current-system/sw/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+    export PATH="${PATH:+$PATH:}$defaults"
 }
 
 log() {
@@ -25,8 +26,33 @@ mount_kernel_filesystems() {
     if [[ $$ -eq 1 ]]; then
         # only mount /run if systemd is not the init
         if ! grep -q "run /run" /proc/mounts; then
+            # The fresh tmpfs hides whatever the rootfs kept under /run. On NixOS
+            # the userland is reached through /run/current-system (a symlink into
+            # the Nix store), so save and restore it across the mount; without it
+            # PATH, the login shell, etc. break.
+            local link target ln_cmd=""
+            local -a preserve=()
+            for link in /run/current-system /run/booted-system; do
+                if target=$(readlink "$link" 2> /dev/null); then
+                    preserve+=("$link" "$target")
+                fi
+            done
+            if ((${#preserve[@]})); then
+                # `ln` lives in /run/current-system/sw/bin on NixOS, which the
+                # mount hides. Resolve its directory out of /run but keep the
+                # `ln` name, so a coreutils multi-call binary still acts as ln.
+                ln_cmd=$(command -v ln)
+                ln_cmd="$(readlink -f "${ln_cmd%/*}")/${ln_cmd##*/}"
+            fi
+
             # Mount tmpfs dirs
             mount -t tmpfs -o mode=0755 run /run/
+
+            local i
+            for ((i = 0; i < ${#preserve[@]}; i += 2)); do
+                "$ln_cmd" -s -- "${preserve[i + 1]}" "${preserve[i]}" ||
+                    log "WARNING: failed to restore symlink ${preserve[i]}"
+            done
         fi
     fi
 

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # virtme-init: virtme's basic init (PID 1) process
 # Copyright © 2014 Andy Lutomirski
 # Licensed under the GPLv2, which is available in the virtme distribution

--- a/virtme/guest/virtme-snapd-script
+++ b/virtme/guest/virtme-snapd-script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Initialize a snap cgroup to emulate a systemd environment, tricking snapd
 # into recognizing our system as a valid one.

--- a/virtme/guest/virtme-sound-script
+++ b/virtme/guest/virtme-sound-script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$(command -v pipewire)" ]; then
     # Start audio system services.

--- a/virtme/guest/virtme-sshd-script
+++ b/virtme/guest/virtme-sshd-script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Initialize ssh server for remote connections (option `--server ssh`)
 

--- a/virtme/guest/virtme-udhcpc-script
+++ b/virtme/guest/virtme-udhcpc-script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # virtme-udhcpc-script: A trivial udhcpc script
 # Copyright © 2014 Andy Lutomirski
 # Licensed under the GPLv2, which is available in the virtme distribution

--- a/virtme_ng/mcp.py
+++ b/virtme_ng/mcp.py
@@ -1784,7 +1784,7 @@ async def run_kselftest_handler(args: dict) -> list[TextContent]:
 
     # Build script with conditional rebuild step
     script_parts = [
-        f"""#!/bin/bash
+        f"""#!/usr/bin/env bash
 set -e  # Exit on any error
 
 echo "======================================================================"

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -669,7 +669,7 @@ ARCH_MAPPING = {
     # adding a new arch? Please also update get_host_arch().
 }
 
-REMOTE_BUILD_SCRIPT = """#!/bin/bash
+REMOTE_BUILD_SCRIPT = """#!/usr/bin/env bash
 cd ~/.virtme
 git reset --hard __virtme__
 [ -f debian/rules ] && fakeroot debian/rules clean

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -464,6 +464,25 @@ fn symlink_fds() {
     }
 }
 
+// Symlinks under /run that must survive the tmpfs mount on /run. On NixOS the whole userland is
+// reached through /run/current-system, so losing it breaks PATH, the login shell, etc.
+const PRESERVED_RUN_SYMLINKS: &[&str] = &["/run/current-system", "/run/booted-system"];
+
+fn save_run_symlinks() -> Vec<(&'static str, PathBuf)> {
+    PRESERVED_RUN_SYMLINKS
+        .iter()
+        .filter_map(|link| std::fs::read_link(link).ok().map(|target| (*link, target)))
+        .collect()
+}
+
+fn restore_run_symlinks(links: &[(&'static str, PathBuf)]) {
+    for (link, target) in links {
+        if let Err(e) = std::os::unix::fs::symlink(target, link) {
+            log!("WARNING: failed to restore symlink {link}: {e}");
+        }
+    }
+}
+
 fn mount_kernel_filesystems() {
     for mount_info in KERNEL_MOUNTS {
         // In the case where a rootfs is specified when launching virtme-ng, it
@@ -473,6 +492,10 @@ fn mount_kernel_filesystems() {
         //
         // Note, get_test_tools_dir() relies on /proc, so that must be mounted
         // prior to /run.
+
+        // The fresh tmpfs hides anything the rootfs kept under /run; save the
+        // symlinks the guest userland depends on so they can be restored after.
+        let mut saved_run_symlinks = Vec::new();
         if mount_info.target == "/run" {
             if id() != 1 {
                 // systemd is the current init, skip mounting /run
@@ -484,6 +507,7 @@ fn mount_kernel_filesystems() {
                     continue;
                 }
             }
+            saved_run_symlinks = save_run_symlinks();
         }
         utils::do_mount(
             mount_info.source,
@@ -492,6 +516,9 @@ fn mount_kernel_filesystems() {
             mount_info.flags,
             mount_info.fsdata,
         );
+        if mount_info.target == "/run" {
+            restore_run_symlinks(&saved_run_symlinks);
+        }
     }
 }
 

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -229,7 +229,11 @@ fn wait_for_child(child: i32) -> Option<i32> {
 }
 
 fn configure_environment() {
-    env::set_var("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin");
+    let defaults = "/run/current-system/sw/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin";
+    match env::var("PATH") {
+        Ok(path) if !path.is_empty() => env::set_var("PATH", format!("{path}:{defaults}")),
+        _ => env::set_var("PATH", defaults),
+    }
 }
 
 fn get_kernel_version(show_machine: bool) -> String {

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -1028,9 +1028,11 @@ fn configure_terminal(consdev: &str, uid: u32) {
             .stdin(File::open(consdev).unwrap())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            // Replace the current init process with a shell session.
             .output();
-        log!("{}", String::from_utf8_lossy(&output.unwrap().stderr));
+        match output {
+            Ok(output) => log!("{}", String::from_utf8_lossy(&output.stderr)),
+            Err(e) => log!("WARNING: failed to run: stty (error: {})", e),
+        }
     }
 }
 


### PR DESCRIPTION
## What

This makes `vng` (default snapshot mode) boot to a working shell when the host — and therefore the guest snapshot — is NixOS. Today it kernel-panics during init and never reaches a shell.

## Why it fails on NixOS

NixOS isn't FHS: programs don't live in `/bin` or `/usr/bin`, they're in `/nix/store` and exposed through the system profile at `/run/current-system/sw/bin`. `virtme-ng-init` assumes an FHS guest, so on a NixOS snapshot it can't find `stty`, `ip`, `su`, or the login shell, and a missing tool aborts PID 1 (`Kernel panic - Attempted to kill init!`).

## Changes

Four small, independent commits:

1. **use portable `#!/usr/bin/env bash` shebang** — guest helper scripts (and the scripts generated by `run.py`/`mcp.py`) hardcoded `#!/bin/bash`, which doesn't exist on NixOS. `env bash` resolves via `PATH` and still works on FHS guests.

2. **vng-init: don't panic if stty is unavailable** — `configure_terminal()` unwrapped the result of running `stty`, so a missing `stty` killed init. Terminal sizing is cosmetic; log a warning and continue, matching how `run_cmd()` already treats other optional tools.

3. **vng-init: preserve NixOS /run symlinks across the tmpfs mount** — init mounts a fresh tmpfs on `/run`, which hides `/run/current-system` (a symlink into the Nix store that the whole userland depends on). Save the targets of `/run/current-system` and `/run/booted-system` before the mount and recreate them after. No-op on guests that don't have them.

4. **vng-init: add the NixOS system profile to the default PATH** — add `/run/current-system/sw/bin` to the init's default `PATH` (it doesn't exist on other distros, so it's harmless there) and append the defaults to any inherited `PATH` instead of overwriting it. This is where `stty`, `ip`, `su`, and the login shell live on NixOS.

## Result

On a NixOS host, `vng` now boots straight to a normal shell — no `--shell` or other workarounds — while non-NixOS guests are unaffected (the added path simply doesn't exist, the symlinks aren't there to save, and the shebang/stty changes are pure improvements).

Tested on a NixOS host booting a v7.0 kernel: clean boot to an interactive shell with `stty`/`ip`/`su` all resolving. `cargo fmt`/`clippy` clean.