### PR TITLE
vng, run: add root POSIX ACL control

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,12 @@ Troubleshooting
    distribution, including minimal ones such as Alpine, but may be missing from
    a hand-built `--root` chroot.
 
+ - Some guest kernels may fail to mount an external virtiofs root filesystem
+   when POSIX ACL support is enabled. This can show up as the root filesystem
+   mount apparently succeeding, followed by `switch_root` failing with
+   `Connection refused` and the guest panicking. In this case, try disabling
+   ACLs on the root virtiofs export with `--no-root-posix-acl`.
+
  - If you get permission denied when starting qemu, make sure that your
    username is assigned to the group `kvm` or `libvirt`:
    ```console

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -117,6 +117,14 @@ def make_parser() -> "VirtmeArgumentParser":
         help="Give the guest read-write access to its root filesystem",
     )
     g.add_argument(
+        "--no-root-posix-acl",
+        action="store_true",
+        help=(
+            "Disable POSIX ACL support for external root virtiofs exports "
+            "(ignored with 9p or host root)"
+        ),
+    )
+    g.add_argument(
         "--gdb",
         action="store",
         nargs="?",
@@ -1602,10 +1610,11 @@ def do_it() -> int:
             path=args.root,
             mount_tag="ROOTFS",
             rw=args.rw,
-            # Only enable POSIX ACLs when using an external root filesystem.
+            # Keep POSIX ACLs enabled by default for external roots, but let
+            # guests whose virtiofs client cannot negotiate ACLs opt out.
             # When sharing the host root (/), --posix-acl breaks UID/GID
             # translation which causes authentication failures.
-            posix_acl=(args.root != "/"),
+            posix_acl=(args.root != "/" and not args.no_root_posix_acl),
         )
         use_virtiofs = export_virtiofs(
             virt_arch,

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -302,6 +302,15 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
     )
 
     parser.add_argument(
+        "--no-root-posix-acl",
+        action="store_true",
+        help=(
+            "Disable POSIX ACL support for external root virtiofs exports "
+            "(ignored with 9p or host root)"
+        ),
+    )
+
+    parser.add_argument(
         "--force-9p", action="store_true", help="Use legacy 9p filesystem as rootfs"
     )
 
@@ -1010,6 +1019,12 @@ class KernelSource:
         else:
             self.virtme_param["rw"] = ""
 
+    def _get_virtme_no_root_posix_acl(self, args):
+        if args.no_root_posix_acl:
+            self.virtme_param["no_root_posix_acl"] = "--no-root-posix-acl"
+        else:
+            self.virtme_param["no_root_posix_acl"] = ""
+
     def _get_virtme_cwd(self, args):
         if args.cwd is not None:
             self.virtme_param["cwd"] = "--cwd " + args.cwd
@@ -1394,6 +1409,7 @@ class KernelSource:
         self._get_virtme_root(args)
         self._get_virtme_systemd(args)
         self._get_virtme_rw(args)
+        self._get_virtme_no_root_posix_acl(args)
         self._get_virtme_rodir(args)
         self._get_virtme_rwdir(args)
         self._get_virtme_overlay_rwdir(args)
@@ -1449,6 +1465,7 @@ class KernelSource:
             + f"{self.virtme_param['root']} "
             + f"{self.virtme_param['systemd']} "
             + f"{self.virtme_param['rw']} "
+            + f"{self.virtme_param['no_root_posix_acl']} "
             + f"{self.virtme_param['rodir']} "
             + f"{self.virtme_param['rwdir']} "
             + f"{self.virtme_param['overlay_rwdir']} "


### PR DESCRIPTION
This came out of testing distro rootfs boots in a GitHub Actions matrix with virtme-ng.

Some arm64 guests, notably Debian 11 and Ubuntu 20.04 in our test matrix, fail to boot when the root filesystem is exported through virtiofs with POSIX ACLs enabled. The failure happens during the rootfs mount path, after the kernel has already booted, and shows up as a broken virtiofs root followed by switch_root failing.

During local reproduction this mapped to the virtiofs client not being able to negotiate POSIX ACL support during FUSE_INIT, so this cannot be reliably probed from the host before starting the guest.

This patch keeps the current default unchanged: external virtiofs roots still use POSIX ACLs by default. It only adds an explicit opt-out (`--no-root-posix-acl`) for setups where the guest/kernel combination cannot handle that negotiationn. The option is ignored for 9p and for host-root sharing, where POSIX ACLs are already not enabled.