### PR TITLE
vng, run: normalize arm64 EFI zboot images

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -41,7 +41,15 @@ from virtme_ng.utils import (
     get_conf,
 )
 
-from .. import architectures, mkinitramfs, modfinder, qemu_helpers, resources, virtmods
+from .. import (
+    architectures,
+    kernel_image,
+    mkinitramfs,
+    modfinder,
+    qemu_helpers,
+    resources,
+    virtmods,
+)
 from ..util import SilentError, find_binary_or_raise, get_username
 
 
@@ -642,10 +650,17 @@ def find_kernel_and_mods(arch, args) -> Kernel:
             if not os.path.exists(kimg):
                 arg_fail(f"{args.kimg} does not exist")
 
+        try:
+            boot_kimg = kernel_image.normalize_kernel_image(
+                arch, kimg, CACHE_DIR, verbose=args.verbose
+            )
+        except kernel_image.KernelImageError as exc:
+            arg_fail(str(exc))
+
         # The for loop is a workaround for s390x to detect the version number
         # from the filename.
         for img_name in arch.img_name():
-            kver = get_kernel_version(kimg, img_name)
+            kver = get_kernel_version(boot_kimg, img_name)
             if kver is not None:
                 break
         else:
@@ -655,17 +670,17 @@ def find_kernel_and_mods(arch, args) -> Kernel:
             args.mods = "none"
             sys.stderr.write(
                 "warning: failed to retrieve kernel version from: "
-                + kimg
+                + boot_kimg
                 + " (modules may not work)\n"
             )
         kernel.version = kver
-        kernel.kimg = kimg
+        kernel.kimg = boot_kimg
         if args.mods == "none":
             kernel.modfiles = []
             kernel.moddir = None
         else:
             # Try to automatically detect modules' path
-            root_dir = get_rootfs_from_kernel_path(kernel.kimg)
+            root_dir = get_rootfs_from_kernel_path(kimg)
             # If we are using the entire host filesystem or if we are using
             # a chroot (via --root) we don't have to do anything special action
             # the modules, just rely on /lib/modules in the target rootfs.

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -24,16 +24,15 @@ import termios
 import threading
 from base64 import b64encode
 from pathlib import Path
-from shutil import which
+from shutil import copyfile, copytree, which
 from time import sleep
 from typing import Any, NoReturn
 
 from virtme_ng.utils import (
     CACHE_DIR,
     DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR,
+    GUEST_CACHE_ROOT,
     KERNEL_CMDLINE_MAX,
-    SERIAL_GETTY_DIR,
-    SERIAL_GETTY_FILE,
     SSH_CONF_FILE,
     SSH_DIR,
     VIRTME_SSH_DESTINATION_NAME,
@@ -1373,8 +1372,11 @@ def ssh_client(args):
         os.execvp("ssh", cmd)
 
 
-def ssh_server(args, arch, qemuargs, kernelargs):
-    # Check if we need to generate the SSH host keys for the guest.
+def ssh_server(args, arch, qemuargs, kernelargs, guest_cache_dir):
+    # Keep host-consumed SSH client state outside of the guest-writable cache.
+    SSH_DIR.mkdir(mode=0o755, parents=True, exist_ok=True)
+
+    # Generate persistent SSH host keys in the host-only cache.
     SSH_ETC_SSH_DIR = SSH_DIR.joinpath("etc", "ssh")
     SSH_ETC_SSH_DIR.mkdir(mode=0o755, parents=True, exist_ok=True)
     subprocess.check_call(["ssh-keygen", "-A", "-f", f"{SSH_DIR}"])
@@ -1392,6 +1394,19 @@ def ssh_server(args, arch, qemuargs, kernelargs):
     if args.root == "/":
         ssh_cache = str(SSH_DIR)
     else:
+        assert guest_cache_dir is not None
+        # Populate the per-invocation guest cache with the server host keys and
+        # public client key. Never expose the private client key or host SSH
+        # configuration, and never reuse files after the guest could modify them.
+        guest_ssh_dir = guest_cache_dir.joinpath(".ssh")
+        copytree(
+            SSH_ETC_SSH_DIR,
+            guest_ssh_dir.joinpath("etc", "ssh"),
+        )
+        copyfile(
+            identity_file.with_suffix(".pub"),
+            guest_ssh_dir.joinpath("id_virtme.pub"),
+        )
         ssh_cache = "/run/virtme/cache/.ssh"
 
     if can_use_ssh_over_vsock(args.ssh_tcp):
@@ -1479,6 +1494,22 @@ def do_it() -> int:
         elif args.client == "ssh":
             ssh_client(args)
         sys.exit(0)
+
+    guest_cache_dir = None
+    serial_getty_dir = None
+    serial_getty_file = None
+    needs_guest_cache = args.systemd or (args.root != "/" and args.server == "ssh")
+    if needs_guest_cache:
+        # Export only a fresh per-invocation directory to the guest. Keeping it
+        # unique prevents one guest from planting files or symlinks that a later
+        # host invocation might trust or overwrite.
+        GUEST_CACHE_ROOT.mkdir(mode=0o755, parents=True, exist_ok=True)
+        guest_cache = tempfile.TemporaryDirectory(prefix="run-", dir=GUEST_CACHE_ROOT)
+        guest_cache_dir = Path(guest_cache.name)
+        os.chmod(guest_cache_dir, 0o755)
+        atexit.register(guest_cache.cleanup)
+        serial_getty_dir = guest_cache_dir.joinpath("serial-getty@.service.d")
+        serial_getty_file = serial_getty_dir.joinpath("virtme-ng.conf")
 
     arch = architectures.get(args.arch)
     is_native = args.arch == platform.machine()
@@ -1687,27 +1718,41 @@ def do_it() -> int:
 
     if args.root == "/":
         if args.systemd:
+            assert guest_cache_dir is not None
             fstab_path = get_conf("systemd.fstab")
             initcmds = [
                 "init=/bin/sh",
                 "--",
                 "-c",
-                f"mount --bind {fstab_path} /etc/fstab && SYSTEMD_UNIT_PATH={CACHE_DIR}: exec /sbin/init;",
+                f"mount --bind {fstab_path} /etc/fstab && SYSTEMD_UNIT_PATH={guest_cache_dir}: exec /sbin/init;",
             ]
         else:
             initcmds = [f"init={guest_tools_path}/{virtme_init_cmd}"]
     else:
-        os.makedirs(CACHE_DIR, exist_ok=True)
-        cache_fstype = export_hostfs(
-            qemu,
-            arch,
-            qemuargs,
-            virtiofs_state,
-            path=str(CACHE_DIR),
-            mount_tag="virtme.cache",
-            readonly=False,
-            verbose=args.verbose,
-        )
+        initsh = ["mount -t tmpfs run /run"]
+        if needs_guest_cache:
+            assert guest_cache_dir is not None
+            guest_cache_fstype = export_hostfs(
+                qemu,
+                arch,
+                qemuargs,
+                virtiofs_state,
+                path=str(guest_cache_dir),
+                mount_tag="virtme.cache",
+                readonly=False,
+                verbose=args.verbose,
+            )
+            initsh.extend(
+                [
+                    "mkdir -p /run/virtme/cache",
+                    hostfs_mount_cmd(
+                        guest_cache_fstype,
+                        "rw",
+                        "virtme.cache",
+                        "/run/virtme/cache",
+                    ),
+                ]
+            )
         guesttools_fstype = export_hostfs(
             qemu,
             arch,
@@ -1718,19 +1763,18 @@ def do_it() -> int:
             verbose=args.verbose,
         )
         fstab_path = get_conf("systemd.fstab")
-        initsh = [
-            "mount -t tmpfs run /run",
-            "mkdir -p /run/virtme/cache",
-            hostfs_mount_cmd(cache_fstype, "rw", "virtme.cache", "/run/virtme/cache"),
-            "mkdir -p /run/virtme/guesttools",
-            hostfs_mount_cmd(
-                guesttools_fstype,
-                "ro",
-                "virtme.guesttools",
-                "/run/virtme/guesttools",
-            ),
-            f"mount --bind {fstab_path} /etc/fstab",
-        ]
+        initsh.extend(
+            [
+                "mkdir -p /run/virtme/guesttools",
+                hostfs_mount_cmd(
+                    guesttools_fstype,
+                    "ro",
+                    "virtme.guesttools",
+                    "/run/virtme/guesttools",
+                ),
+                f"mount --bind {fstab_path} /etc/fstab",
+            ]
+        )
         if host_busybox is not None and busybox_guest_path is None:
             busybox_fstype = export_hostfs(
                 qemu,
@@ -2222,7 +2266,7 @@ def do_it() -> int:
         if args.server == "console":
             console_server(args, qemu, arch, qemuargs, kernelargs, virtiofs_state)
         elif args.server == "ssh":
-            ssh_server(args, arch, qemuargs, kernelargs)
+            ssh_server(args, arch, qemuargs, kernelargs, guest_cache_dir)
 
     if args.pwd:
         rel_pwd = get_guest_relative_path(os.getcwd(), args.root)
@@ -2370,14 +2414,16 @@ def do_it() -> int:
     qemuargs.extend(["-kernel", kernel.kimg])
     if kernelargs:
         if args.systemd:
+            assert serial_getty_dir is not None
+            assert serial_getty_file is not None
             init_environment_vars = []
             for arg in kernelargs:
                 match = re.match(r"(virtme_.*)=(.*)", arg)
                 if not match:
                     continue
                 init_environment_vars.append(f"{match.group(1)}={match.group(2)}")
-            os.makedirs(SERIAL_GETTY_DIR, exist_ok=True)
-            with open(SERIAL_GETTY_FILE, "w", encoding="utf-8") as f:
+            os.makedirs(serial_getty_dir, exist_ok=True)
+            with open(serial_getty_file, "w", encoding="utf-8") as f:
                 f.write(
                     f"""[Service]
 StandardInput=tty

--- a/virtme/kernel_image.py
+++ b/virtme/kernel_image.py
@@ -57,11 +57,43 @@ def normalize_kernel_image(arch, path: str, cache_dir: Path, verbose=False) -> s
 
     image = Path(path)
     try:
+        with image.open("rb") as stream:
+            header = stream.read(ARM64_IMAGE_MAGIC_OFFSET + len(ARM64_IMAGE_MAGIC))
+    except OSError as exc:
+        raise KernelImageError(f"failed to read kernel image {image}: {exc}") from exc
+
+    # Avoid reading and hashing the complete file in the common case where QEMU
+    # can consume an already-plain arm64 Image directly.
+    if _is_arm64_image(header):
+        return path
+
+    output = _cached_image_path(cache_dir, image)
+    if output.is_file():
+        if verbose:
+            print(
+                f"virtme: using normalized arm64 kernel image {output}",
+                file=sys.stderr,
+            )
+        return str(output)
+
+    try:
         data = image.read_bytes()
     except OSError as exc:
         raise KernelImageError(f"failed to read kernel image {image}: {exc}") from exc
 
-    output = _cached_image_path(cache_dir, data)
+    # The image may have been replaced after the streaming hash above. Derive
+    # the publication path from the exact bytes that will be normalized so the
+    # cache remains content-addressed. This also notices a cache entry published
+    # by a concurrent invocation after the first lookup.
+    output = _cached_image_path_from_digest(cache_dir, hashlib.sha256(data).hexdigest())
+    if output.is_file():
+        if verbose:
+            print(
+                f"virtme: using normalized arm64 kernel image {output}",
+                file=sys.stderr,
+            )
+        return str(output)
+
     if not _prepare_arm64_image(data, image, output):
         return path
 
@@ -295,8 +327,18 @@ def _decompressed_image_too_large(image: Path) -> KernelImageError:
     )
 
 
-def _cached_image_path(cache_dir: Path, data: bytes) -> Path:
-    digest = hashlib.sha256(data).hexdigest()
+def _cached_image_path(cache_dir: Path, image: Path) -> Path:
+    digest = hashlib.sha256()
+    try:
+        with image.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise KernelImageError(f"failed to read kernel image {image}: {exc}") from exc
+    return _cached_image_path_from_digest(cache_dir, digest.hexdigest())
+
+
+def _cached_image_path_from_digest(cache_dir: Path, digest: str) -> Path:
     return Path(cache_dir, "kernel-images", "arm64", digest, "Image")
 
 

--- a/virtme/kernel_image.py
+++ b/virtme/kernel_image.py
@@ -1,0 +1,332 @@
+# -*- mode: python -*-
+# kernel_image: Normalize kernel images for QEMU direct boot
+# Licensed under the GPLv2, which is available in the virtme distribution
+# as a file called LICENSE with SHA-256 hash:
+# 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643
+
+"""Helpers to normalize distro kernel images before passing them to QEMU."""
+
+import gzip
+import hashlib
+import io
+import os
+import resource
+import signal
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+GZIP_MAGIC = b"\x1f\x8b"
+PE_MSDOS_MAGIC = b"MZ"
+PE_SIGNATURE = b"PE\0\0"
+ARM64_IMAGE_MAGIC = b"ARM\x64"
+ZBOOT_MAGIC = b"zimg"
+EFI_PE_LINUX_MAGIC = b"\xcd\x23\x82\x81"
+
+ARM64_IMAGE_MAGIC_OFFSET = 56
+# Match QEMU's LOAD_IMAGE_MAX_DECOMPRESSED_BYTES limit used by its arm64 loader.
+MAX_DECOMPRESSED_SIZE = 256 * 1024 * 1024
+
+PE_HEADER_OFFSET = 0x3C
+PE_SIGNATURE_SIZE = 4
+COFF_HEADER_SIZE = 20
+SECTION_HEADER_SIZE = 40
+SECTION_NAME_SIZE = 8
+SECTION_COUNT_OFFSET = 6
+OPTIONAL_HEADER_SIZE_OFFSET = 20
+SECTION_RAW_SIZE_OFFSET = 16
+SECTION_RAW_OFFSET_OFFSET = 20
+
+ZBOOT_HEADER_SIZE = 64
+ZBOOT_PAYLOAD_OFFSET = 8
+ZBOOT_PAYLOAD_SIZE = 12
+ZBOOT_COMPRESSION_TYPE = slice(24, 56)
+ZBOOT_LINUX_MAGIC = slice(56, 60)
+
+
+class KernelImageError(Exception):
+    pass
+
+
+def normalize_kernel_image(arch, path: str, cache_dir: Path, verbose=False) -> str:
+    # QEMU's arm64 -kernel path expects the bootloader to hand it a plain Image,
+    # but distro kernels may be wrapped as EFI zboot images.
+    if getattr(arch, "linuxname", None) != "arm64":
+        return path
+
+    image = Path(path)
+    try:
+        data = image.read_bytes()
+    except OSError as exc:
+        raise KernelImageError(f"failed to read kernel image {image}: {exc}") from exc
+
+    output = _cached_image_path(cache_dir, data)
+    if not _prepare_arm64_image(data, image, output):
+        return path
+
+    if verbose:
+        print(f"virtme: using normalized arm64 kernel image {output}", file=sys.stderr)
+    return str(output)
+
+
+def _prepare_arm64_image(data: bytes, image: Path, output: Path) -> bool:
+    work = _gunzip_if_needed(data, image)
+    linux_section = _pe_section(work, b".linux")
+    if linux_section is not None:
+        work = _gunzip_if_needed(linux_section, image)
+        if _is_arm64_image(work):
+            if not output.exists():
+                _write_atomic(output, work)
+            return True
+    elif _is_arm64_image(work):
+        return False
+
+    zboot = _parse_zboot(work)
+    if zboot is None:
+        if linux_section is not None or _is_pe_image(work):
+            sys.stderr.write(
+                f"virtme: warning: {image} looks like an EFI application "
+                "that could not be normalized; QEMU -kernel may not boot it\n"
+            )
+        return False
+
+    compression, payload = zboot
+    if compression == "gzip":
+        try:
+            prepared = _decompress_gzip(payload, image)
+        except (EOFError, OSError) as exc:
+            raise KernelImageError(
+                f"failed to decompress arm64 EFI zboot image {image}: {exc}"
+            ) from exc
+        if not output.exists():
+            _write_atomic(output, prepared)
+        return True
+    if compression == "zstd":
+        if not output.exists():
+            _decompress_zstd(payload, image, output)
+        return True
+    if compression in ("", "none"):
+        if not output.exists():
+            _write_atomic(output, payload)
+        return True
+
+    raise KernelImageError(
+        f"unsupported arm64 EFI zboot compression in {image}: {compression}"
+    )
+
+
+def _gunzip_if_needed(data: bytes, image: Path) -> bytes:
+    if not data.startswith(GZIP_MAGIC):
+        return data
+
+    try:
+        return _decompress_gzip(data, image)
+    except (EOFError, OSError):
+        return data
+
+
+def _decompress_gzip(data: bytes, image: Path) -> bytes:
+    with gzip.GzipFile(fileobj=io.BytesIO(data)) as stream:
+        # Read one byte past the limit to distinguish an exact-size image from
+        # an oversized one without decompressing the rest of the input.
+        output = stream.read(MAX_DECOMPRESSED_SIZE + 1)
+    if len(output) > MAX_DECOMPRESSED_SIZE:
+        raise _decompressed_image_too_large(image)
+    return output
+
+
+def _pe_header_offset(data: bytes) -> int | None:
+    if len(data) < 0x40 or not data.startswith(PE_MSDOS_MAGIC):
+        return None
+
+    pe_offset = _u32(data, PE_HEADER_OFFSET)
+    if pe_offset is None or pe_offset + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE > len(
+        data
+    ):
+        return None
+    if data[pe_offset : pe_offset + PE_SIGNATURE_SIZE] != PE_SIGNATURE:
+        return None
+    return pe_offset
+
+
+def _is_pe_image(data: bytes) -> bool:
+    return _pe_header_offset(data) is not None
+
+
+def _is_arm64_image(data: bytes) -> bool:
+    magic_end = ARM64_IMAGE_MAGIC_OFFSET + len(ARM64_IMAGE_MAGIC)
+    return len(data) >= magic_end and (
+        data[ARM64_IMAGE_MAGIC_OFFSET:magic_end] == ARM64_IMAGE_MAGIC
+    )
+
+
+def _pe_section(data: bytes, name: bytes) -> bytes | None:
+    # Minimal PE/COFF section-table reader:
+    #   0x00: MS-DOS header, starts with "MZ"
+    #   0x3c: little-endian offset of the PE signature
+    #   PE header:
+    #     +0:  "PE\0\0" signature
+    #     +6:  section count
+    #     +20: optional header size
+    #   Section table:
+    #     one 40-byte header per section
+    #     +0:  8-byte NUL-padded section name
+    #     +16: raw section size
+    #     +20: raw section file offset
+
+    pe_offset = _pe_header_offset(data)
+    if pe_offset is None:
+        return None
+
+    section_count = _u16(data, pe_offset + SECTION_COUNT_OFFSET)
+    optional_header_size = _u16(data, pe_offset + OPTIONAL_HEADER_SIZE_OFFSET)
+    if section_count is None or optional_header_size is None:
+        return None
+
+    section_offset = pe_offset + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE
+    section_offset += optional_header_size
+    for index in range(section_count):
+        offset = section_offset + index * SECTION_HEADER_SIZE
+        if offset + SECTION_HEADER_SIZE > len(data):
+            return None
+
+        section_name = data[offset : offset + SECTION_NAME_SIZE].rstrip(b"\0")
+        if section_name != name:
+            continue
+
+        raw_size = _u32(data, offset + SECTION_RAW_SIZE_OFFSET)
+        raw_offset = _u32(data, offset + SECTION_RAW_OFFSET_OFFSET)
+        if raw_size is None or raw_offset is None:
+            return None
+        if raw_size == 0 or raw_offset + raw_size > len(data):
+            return None
+        return data[raw_offset : raw_offset + raw_size]
+
+    return None
+
+
+def _parse_zboot(data: bytes) -> tuple[str, bytes] | None:
+    # Linux EFI zboot header:
+    #   +0:  MS-DOS magic, "MZ"
+    #   +4:  image type, "zimg"
+    #   +8:  little-endian payload offset
+    #   +12: little-endian payload size
+    #   +24: NUL-terminated compression type, up to 32 bytes
+    #   +56: Linux PE magic
+    if (
+        len(data) < ZBOOT_HEADER_SIZE
+        or data[0:2] != PE_MSDOS_MAGIC
+        or data[4:8] != ZBOOT_MAGIC
+        or data[ZBOOT_LINUX_MAGIC] != EFI_PE_LINUX_MAGIC
+    ):
+        return None
+
+    payload_offset = _u32(data, ZBOOT_PAYLOAD_OFFSET)
+    payload_size = _u32(data, ZBOOT_PAYLOAD_SIZE)
+    if payload_offset is None or payload_size is None:
+        return None
+    if payload_size == 0 or payload_offset + payload_size > len(data):
+        raise KernelImageError("invalid arm64 EFI zboot payload range")
+
+    compression = data[ZBOOT_COMPRESSION_TYPE].split(b"\0", 1)[0]
+    compression = compression.decode("ascii", errors="replace")
+    payload = data[payload_offset : payload_offset + payload_size]
+    return compression, payload
+
+
+def _decompress_zstd(payload: bytes, image: Path, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = None
+    try:
+        # zstd can write directly to the same-directory temporary file used for
+        # atomic publication. _write_atomic() takes bytes, which would require
+        # buffering the complete decompressed image in Python first.
+        with tempfile.NamedTemporaryFile(dir=output.parent, delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            proc = subprocess.run(
+                ["zstd", "-q", "-d", "-c"],
+                input=payload,
+                stdout=tmp,
+                stderr=subprocess.PIPE,
+                check=False,
+                # Set the output-file limit in the child before executing zstd,
+                # without changing the limits of the virtme-ng process.
+                preexec_fn=_limit_decompressed_output,
+            )
+    except FileNotFoundError as exc:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+        raise KernelImageError(
+            f"arm64 EFI zboot image {image} uses zstd compression, "
+            "but zstd is not installed"
+        ) from exc
+    except Exception:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+        raise
+
+    assert tmp_path is not None
+    # Exceeding RLIMIT_FSIZE makes the kernel terminate zstd with SIGXFSZ.
+    # Python reports signal termination as the negative signal number.
+    if proc.returncode == -signal.SIGXFSZ:
+        tmp_path.unlink(missing_ok=True)
+        raise _decompressed_image_too_large(image)
+    if proc.returncode != 0:
+        error = proc.stderr.decode("utf-8", errors="replace").strip()
+        tmp_path.unlink(missing_ok=True)
+        raise KernelImageError(
+            f"failed to decompress arm64 EFI zboot image {image}: {error}"
+        )
+    _publish_atomic(output, tmp_path)
+
+
+def _limit_decompressed_output() -> None:
+    resource.setrlimit(
+        resource.RLIMIT_FSIZE,
+        (MAX_DECOMPRESSED_SIZE, MAX_DECOMPRESSED_SIZE),
+    )
+
+
+def _decompressed_image_too_large(image: Path) -> KernelImageError:
+    limit_mib = MAX_DECOMPRESSED_SIZE // (1024 * 1024)
+    return KernelImageError(
+        f"decompressed arm64 kernel image {image} exceeds the {limit_mib} MiB limit"
+    )
+
+
+def _cached_image_path(cache_dir: Path, data: bytes) -> Path:
+    digest = hashlib.sha256(data).hexdigest()
+    return Path(cache_dir, "kernel-images", "arm64", digest, "Image")
+
+
+def _write_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # The cache path is content-addressed, so parallel virtme-ng instances may
+    # normalize the same image. Write a complete temporary file first, then
+    # publish it with an atomic rename inside the same directory.
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as tmp:
+        tmp.write(data)
+        tmp_path = Path(tmp.name)
+    _publish_atomic(path, tmp_path)
+
+
+def _publish_atomic(path: Path, tmp_path: Path) -> None:
+    try:
+        os.chmod(tmp_path, 0o644)
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _u16(data: bytes, offset: int) -> int | None:
+    if offset + 2 > len(data):
+        return None
+    return int.from_bytes(data[offset : offset + 2], "little")
+
+
+def _u32(data: bytes, offset: int) -> int | None:
+    if offset + 4 > len(data):
+        return None
+    return int.from_bytes(data[offset : offset + 4], "little")

--- a/virtme_ng/utils.py
+++ b/virtme_ng/utils.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 from virtme_ng.spinner import Spinner
 
+# Host-trusted cache data must remain outside of any guest-writable export.
 CACHE_DIR = Path(Path.home(), ".cache", "virtme-ng")
+# Only fresh per-invocation children of this directory are exported to guests.
+GUEST_CACHE_ROOT = Path(CACHE_DIR, "guest")
 SSH_DIR = Path(CACHE_DIR, ".ssh")
 SSH_CONF_FILE = SSH_DIR.joinpath("virtme-ng-ssh.conf")
 VIRTME_SSH_DESTINATION_NAME = "virtme-ng"
@@ -16,9 +19,6 @@ VIRTME_SSH_HOSTNAME_CID_SEPARATORS = ("%", "/")
 DEFAULT_VIRTME_SSH_HOSTNAME_CID_SEPARATOR = VIRTME_SSH_HOSTNAME_CID_SEPARATORS[0]
 CONF_PATH = Path(Path.home(), ".config", "virtme-ng")
 CONF_FILE = Path(CONF_PATH, "virtme-ng.conf")
-SERIAL_GETTY_DIR = Path(CACHE_DIR, "serial-getty@.service.d")
-SERIAL_GETTY_FILE = Path(SERIAL_GETTY_DIR, "virtme-ng.conf")
-
 # When using external rootfs, the kernel cmdline should be kept under 896 bytes
 # to maximize compatibility with old systems. This number is the legacy hardlimit
 # for s390x hosts.


### PR DESCRIPTION
Several current arm64 distro kernels are no longer plain Image files from QEMU's point of view. Fedora 44 and recent Ubuntu development releases ship EFI zboot images, and some Ubuntu kernels add another signed PE wrapper around the bootable payload. Passing those files directly through QEMU's `-kernel` either fails or hangs before the guest reaches userspace.

The practical symptom was confusing: virtme-ng appeared to be waiting for virtiofsd/rootfs setup, but the real issue was earlier: QEMU had not consumed a bootable arm64 kernel image.

This patch normalizes only arm64 kernel images before passing them to QEMU. If the selected image is a PE wrapper with a `.linux` payload, it extracts that payload. If the result is an EFI zboot image, it unwraps and decompresses it to a plain arm64 Image. The normalized Image is cached by input content hash, so the conversion is deterministic and does not repeat unnecessarily. Already-plain images and non-arm64 kernels are left untouched. Module/rootfs discovery still uses the original distro kernel path, while QEMU receives the normalized Image.

This follows the same general path modern QEMU already uses for arm64 direct kernel boot: [`load_aarch64_image()`](https://gitlab.com/qemu-project/qemu/-/blob/ab2056a0b7c944b16b224a8feabd99023772ae91/hw/arm/boot.c#L816) tries to normalize EFI zboot images before checking for the plain arm64 Image magic, and [`unpack_efi_zboot_image()`](https://gitlab.com/qemu-project/qemu/-/blob/ab2056a0b7c944b16b224a8feabd99023772ae91/hw/core/loader.c#L902) parses the Linux EFI zboot header metadata.

So QEMU already supports part of this path for arm64 direct kernel boot. However, it still leaves two practical gaps for virtme-ng users: QEMU does not unwrap an outer PE/UKI-style wrapper to extract the `.linux` payload before applying its zboot handling, and older versions do not support the zboot compression used by current distros. Doing this in virtme-ng makes the behavior deterministic.

This was tested against real distro rootfs images in CI. In particular, Fedora 44, Ubuntu 25.10, and Ubuntu 26.04 arm64 moved from failing before boot to booting far enough to compile the module successfully.