### PR TITLE
virtme-init: Use setsid -c to steal controlling tty under systemd

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -559,9 +559,9 @@ run_user_script_on_console() {
     log 'starting script (console fallback)'
     if [[ -n ${virtme_user:-} ]]; then
         chmod +x /run/tmp/.virtme-script
-        setsid su -c /run/tmp/.virtme-script -- "${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
+        setsid -c su -c /run/tmp/.virtme-script -- "${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
     else
-        setsid bash /run/tmp/.virtme-script 0<> "/dev/$consdev" 1>&0 2>&0
+        setsid -c bash /run/tmp/.virtme-script 0<> "/dev/$consdev" 1>&0 2>&0
     fi
     ret=$?
     log "script returned {$ret}"
@@ -712,9 +712,9 @@ run_user_gui() {
         # Try to fix permissions on the virtual consoles, we are starting X
         # directly here so we may need extra permissions on the tty devices.
         chown -- "${virtme_user}" /dev/char/*
-        setsid bash -c "su -c 'xinit ${xinit_rc}' -- ${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
+        setsid -c bash -c "su -c 'xinit ${xinit_rc}' -- ${virtme_user}" 0<> "/dev/$consdev" 1>&0 2>&0
     else
-        setsid bash -c "xinit ${xinit_rc}" 0<> "/dev/$consdev" 1>&0 2>&0
+        setsid -c bash -c "xinit ${xinit_rc}" 0<> "/dev/$consdev" 1>&0 2>&0
     fi
 }
 
@@ -726,7 +726,7 @@ run_user_shell() {
 
     [[ -n ${virtme_shell:-} ]] && args+=(-s "$virtme_shell")
     [[ -n ${virtme_user:-} ]] && args+=(-- "$virtme_user")
-    setsid bash -c "su ${args[*]}" 0<> "/dev/$consdev" 1>&0 2>&0
+    setsid -c bash -c "su ${args[*]}" 0<> "/dev/$consdev" 1>&0 2>&0
 }
 
 run_user_session() {


### PR DESCRIPTION
Hi,

Please consider merging these two small fixes:

virtme-init: Prevent udevd from blocking initialization
virtme-init: Use setsid -c to steal controlling tty under systemd

They were found while testing SLES version 12.5