### PR TITLE
systemd: Don't re-mount /proc, /sys or cgroup2

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -19,11 +19,11 @@ log() {
 }
 
 mount_kernel_filesystems() {
-    # Mount procfs and sysfs (needed for stat, sadly)
-    mount -t proc -o nosuid,noexec,nodev proc /proc/
-    mount -t sysfs -o nosuid,noexec,nodev sys /sys/
-
     if [[ $$ -eq 1 ]]; then
+        # Mount procfs and sysfs (needed for stat, sadly).
+        mount -t proc -o nosuid,noexec,nodev proc /proc/
+        mount -t sysfs -o nosuid,noexec,nodev sys /sys/
+
         # only mount /run if systemd is not the init
         if ! grep -q "run /run" /proc/mounts; then
             # The fresh tmpfs hides whatever the rootfs kept under /run. On NixOS
@@ -277,6 +277,10 @@ run_systemd_tmpfiles() {
 mount_cgroupfs() {
     # Set up cgroup mount points (mount cgroupv2 hierarchy by default)
     #
+    if [[ $$ -ne 1 ]]; then
+        # systemd is the current init, skip mounting cgroup
+        return
+    fi
     # If SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 is passed we can mimic systemd's
     # behavior and mount the legacy cgroup v1 layout.
     if grep -q -E '(^| )SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1($| )' /proc/cmdline; then

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -497,6 +497,10 @@ fn mount_kernel_filesystems() {
         // Note, get_test_tools_dir() relies on /proc, so that must be mounted
         // prior to /run.
 
+        if (mount_info.target == "/proc" || mount_info.target == "/sys") && id() != 1 {
+            continue;
+        }
+
         // The fresh tmpfs hides anything the rootfs kept under /run; save the
         // symlinks the guest userland depends on so they can be restored after.
         let mut saved_run_symlinks = Vec::new();
@@ -527,6 +531,10 @@ fn mount_kernel_filesystems() {
 }
 
 fn mount_cgroupfs() {
+    if id() != 1 {
+        // systemd is the current init, skip mounting cgroup
+        return;
+    }
     // If SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 is passed we can mimic systemd's behavior and mount
     // the legacy cgroup v1 layout.
     let cmdline = std::fs::read_to_string("/proc/cmdline").unwrap();


### PR DESCRIPTION
When virtme-init runs as PID 1 it needs to set up procfs, sysfs and the cgroup2 hierarchy from scratch. But under --systemd, virtme-init is instead invoked later as a plain service (the serial-getty@ override), in the same non-isolated mount namespace as the already-running real init, which has already mounted /proc, /sys and /sys/fs/cgroup itself and is actively managing them.