### PR TITLE
virtme-init: Tolerate a missing /etc/hosts when setting the guest hostname

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -192,7 +192,11 @@ generate_fstab() {
 
 generate_hosts() {
     if [[ -n ${virtme_hostname:-} ]]; then
-        cp /etc/hosts /run/tmp/hosts
+        if [[ -e /etc/hosts ]]; then
+            cp /etc/hosts /run/tmp/hosts
+        else
+            touch /etc/hosts
+        fi
         printf '\n127.0.0.1 %s\n::1 %s\n' "$virtme_hostname" "$virtme_hostname" >> /run/tmp/hosts
         mount --bind /run/tmp/hosts /etc/hosts
     fi

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -396,8 +396,15 @@ fn generate_lvm() -> io::Result<()> {
 
 fn generate_hosts() -> io::Result<()> {
     if let Ok(hostname) = env::var("virtme_hostname") {
-        std::fs::copy("/etc/hosts", "/run/tmp/hosts")?;
-        let mut h = OpenOptions::new().append(true).open("/run/tmp/hosts")?;
+        if Path::new("/etc/hosts").exists() {
+            std::fs::copy("/etc/hosts", "/run/tmp/hosts")?;
+        } else {
+            utils::create_file("/etc/hosts", 0o0644, "")?;
+        }
+        let mut h = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open("/run/tmp/hosts")?;
         writeln!(h, "\n127.0.0.1 {hostname}\n::1 {hostname}")?;
         utils::do_mount(
             "/run/tmp/hosts",


### PR DESCRIPTION
generate_hosts() copies /etc/hosts to /run/tmp/hosts, appends the guest
hostname entries and bind-mounts the result back over /etc/hosts. However,
minimal external roots may ship no /etc/hosts at all, so the copy fails and
the bind-mount then has no source or target:

  cp: cannot stat '/etc/hosts': No such file or directory
  mount: /etc/hosts: mount point does not exist.