### PR TITLE
run: Mount devtmpfs before the fstab bind-mount on external roots

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1729,7 +1729,10 @@ def do_it() -> int:
         else:
             initcmds = [f"init={guest_tools_path}/{virtme_init_cmd}"]
     else:
-        initsh = ["mount -t tmpfs run /run"]
+        initsh = [
+            "mount -t tmpfs run /run",
+            "mount -t devtmpfs devtmpfs /dev",
+        ]
         if needs_guest_cache:
             assert guest_cache_dir is not None
             guest_cache_fstype = export_hostfs(


### PR DESCRIPTION
The external-root init one-liner bind-mounts /dev/null over /etc/fstab to blank out entries that may reference devices absent from the guest. This assumes /dev/null already exists as a static node in the target rootfs, which minimal images built without a populated /dev do not provide. The bind-mount then fails right after switch_root, before virtme-init gets a chance to mount devtmpfs itself:

  mount: /etc/fstab: special device /dev/null does not exist.