### PR TITLE
run: Only cd ssh guest to host cwd when --pwd is passed

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1331,12 +1331,14 @@ def ssh_client(args):
         ssh_destination = f"ssh://{VIRTME_SSH_DESTINATION_NAME}:{args.port}"
 
     force_tty = False
-    if args.cwd is not None:
+    if args.pwd:
+        cwd = get_guest_relative_path(os.getcwd(), args.root)
+    elif args.cwd is not None:
         cwd = get_guest_relative_path(args.cwd, args.root)
         if cwd is None:
             arg_fail("specified working directory is not contained in the root")
     else:
-        cwd = get_guest_relative_path(os.getcwd(), args.root)
+        cwd = None
 
     if cwd is not None:
         guest_cwd = "/" if cwd == "." else f"/{cwd}"

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -1028,7 +1028,7 @@ class KernelSource:
     def _get_virtme_cwd(self, args):
         if args.cwd is not None:
             self.virtme_param["cwd"] = "--cwd " + args.cwd
-        elif args.root is None:
+        elif args.root is None or args.ssh_client is not None:
             self.virtme_param["cwd"] = "--pwd"
         else:
             self.virtme_param["cwd"] = ""


### PR DESCRIPTION
ssh_client() cd'd the guest shell into the host's current directory, mapped through --root, even when neither --pwd nor --cwd was requested. That's only meaningful when --root is "/", the default. But with any other --root the resulting path belongs to the host tree, not the guest one, and usually doesn't exist there.

Compute that path only when --pwd is passed, like console_client() and main() already do, so by default the guest's starting directory is left alone.