### PR TITLE
run: fail clearly when `make` is missing for --kconfig/--build

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -405,6 +405,10 @@ def do_it():
             print(conf_item.rstrip("\n"))
         return 0
 
+    if shutil.which("make") is None:
+        sys.stderr.write("Error: 'make' is not installed or not found in PATH.\n")
+        return 1
+
     linuxname = shlex.quote(arch.linuxname)
     archargs = [f"ARCH={linuxname}"]
 

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -921,6 +921,17 @@ class KernelSource:
             make_command += [f"CROSS_COMPILE={cross_compile}", f"ARCH={cross_arch}"]
         # Propagate additional Makefile variables
         make_command += args.envs
+
+        if (
+            not args.dry_run
+            and (args.build_host is None or not args.skip_modules)
+            and shutil.which("make") is None
+        ):
+            arg_fail(
+                "Error: 'make' is not installed or not found in PATH.",
+                show_usage=False,
+            )
+
         if args.build_host is None:
             # Build the kernel locally
             make_command += ["-j", str(args.jobs) if args.jobs else self.cpus]


### PR DESCRIPTION
When `make` is not installed (or not in PATH), `vng --kconfig` and `vng --build` can fail with exit code 1 and no user-facing error.

Add an explicit check before invoking configkernel/make flows and print a clear diagnostic so users can install the missing dependency.

Closes: #485