### PR TITLE
virtme: Find the correct mod_path to use kmod utils

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -690,8 +690,8 @@ def find_kernel_and_mods(arch, args) -> Kernel:
                 kernel.modfiles = []
                 kernel.moddir = None
             else:
-                mod_file = os.path.join(kernel.moddir, "modules.dep")
-                if not os.path.exists(mod_file):
+                mod_path = modfinder.get_mod_path(root_dir, kver)
+                if not Path(kernel.moddir, "modules.dep").exists():
                     depmod = find_binary_or_raise(["depmod"])
 
                     if args.verbose:
@@ -701,11 +701,11 @@ def find_kernel_and_mods(arch, args) -> Kernel:
                     # don't ship all the required modules information, so we
                     # need to refresh the modules directory using depmod.
                     subprocess.call(
-                        [depmod, "-a", "-b", root_dir, kver],
+                        [depmod, "-a", "-b", mod_path, kver],
                         stderr=subprocess.DEVNULL,
                     )
                 kernel.modfiles = modfinder.find_modules_from_install(
-                    virtmods.MODALIASES, root=root_dir, kver=kver
+                    virtmods.MODALIASES, root=mod_path, kver=kver
                 )
         kernel.dtb = None  # For now
     elif args.kdir is not None:

--- a/virtme/modfinder.py
+++ b/virtme/modfinder.py
@@ -12,11 +12,12 @@ everything.  The idea is to require very few modules.
 """
 
 import itertools
+import os
 import platform
 import re
 import subprocess
 
-from . import util
+from . import util, virtmods
 
 _INSMOD_RE = re.compile("insmod (.*[^ ]) *$")
 
@@ -67,3 +68,34 @@ def find_modules_from_install(aliases, root=None, kver=None, moddir=None):
     return merge_mods(
         resolve_dep(a, root=root, kver=kver, moddir=moddir) for a in aliases
     )
+
+
+def get_mod_path(path, kver):
+    """
+    There are cases where the path to the modules dir can conflictn with
+    depmod. For example, if root_dir points to /../dir/usr, and the default
+    depmod module path is /usr/lib/modules, it won't find the modules path
+    to create modules.dep inside /../dir/usr/usr/lib/modules/, and making
+    depmod/modprobe to not work properly.
+
+    Execute modprobe, using the first of the virtmods, on the given path until
+    it find a working directory.
+    """
+    modprobe = util.find_binary_or_raise(["modprobe"])
+
+    while path and path != "/":
+        try:
+            subprocess.run(
+                [modprobe, "--show-depends", "-C", "/var/empty", "-d", path, "-S", kver, "--",
+                    virtmods.MODALIASES[0]],
+                check=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL
+            )
+
+            return path
+
+        except subprocess.CalledProcessError:
+            pass  # This is most likely because the module is built in.
+
+        path, _ = os.path.split(path)
+
+    return None


### PR DESCRIPTION
When vng is ran targetting a kernel that was extracted from packages, sometimes the modules.dep file doesn't exists. In these cases the process of creating might fails due to the fixed moduledir setting when compiling kmod with usrmerge.

For example, when running

    vng -r kernels/kernel-default-6.4.0-35.1.x86_64/usr/lib/modules/6.4.0-35-default/vmlinuz

The code will eventually call get_rootfs_from_kernel_path, which might return kernels/..../usr due to other constratins and interoperability.

If modules.dep does not exists for the returned path + lib/modules/{kver}, it then calls depmod, passing the path ending with usr/ as --basedir.

In the case of a newer kmod, or if the default --moduledir is /usr/lib/modules, it will fail to create the modules.dep, and also fail to find the necessary modules to create the initrd to boot the VM.

To solve this issue, and keep everything working for other distributions, keep the root_dir in place, but find a working module path, and use it to create the modules.dep file, if necessary, and to find the other modules.

I found this situation when I extracted the kernel-default package on openSUSE, and just tried to use it with a random rootfs. The extracted directory didn't contain the modules.dep, making it get stuck.