### PR TITLE
modfinder: Resolve a depmod/modprobe-compatible basedir via get_mod_path

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -700,10 +700,16 @@ def find_kernel_and_mods(arch, args) -> Kernel:
                     # Try to refresh modules directory. Some packages (e.g., debs)
                     # don't ship all the required modules information, so we
                     # need to refresh the modules directory using depmod.
-                    subprocess.call(
+                    ret = subprocess.call(
                         [depmod, "-a", "-b", root_dir, kver],
                         stderr=subprocess.DEVNULL,
                     )
+                    if ret != 0 or not os.path.exists(mod_file):
+                        sys.stderr.write(
+                            "virtme: warning: depmod failed to generate "
+                            f"modules.dep for {kernel.moddir} (exit {ret}); "
+                            "module auto-detection may not work\n"
+                        )
                 kernel.modfiles = modfinder.find_modules_from_install(
                     virtmods.MODALIASES, root=root_dir, kver=kver
                 )

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -691,28 +691,31 @@ def find_kernel_and_mods(arch, args) -> Kernel:
                 kernel.moddir = None
             else:
                 mod_file = os.path.join(kernel.moddir, "modules.dep")
-                if not os.path.exists(mod_file):
-                    depmod = find_binary_or_raise(["depmod"])
+                with modfinder.get_mod_path(kernel.moddir, kver) as mod_path:
+                    if not os.path.exists(mod_file):
+                        depmod = find_binary_or_raise(["depmod"])
 
-                    if args.verbose:
-                        sys.stderr.write("virtme: generating modules.dep file\n")
+                        if args.verbose:
+                            sys.stderr.write("virtme: generating modules.dep file\n")
 
-                    # Try to refresh modules directory. Some packages (e.g., debs)
-                    # don't ship all the required modules information, so we
-                    # need to refresh the modules directory using depmod.
-                    ret = subprocess.call(
-                        [depmod, "-a", "-b", root_dir, kver],
-                        stderr=subprocess.DEVNULL,
-                    )
-                    if ret != 0 or not os.path.exists(mod_file):
-                        sys.stderr.write(
-                            "virtme: warning: depmod failed to generate "
-                            f"modules.dep for {kernel.moddir} (exit {ret}); "
-                            "module auto-detection may not work\n"
+                        # Try to refresh modules directory. Some packages (e.g., debs)
+                        # don't ship all the required modules information, so we
+                        # need to refresh the modules directory using depmod.
+                        ret = subprocess.call(
+                            [depmod, "-a", "-b", mod_path, kver],
+                            stderr=subprocess.DEVNULL,
                         )
-                kernel.modfiles = modfinder.find_modules_from_install(
-                    virtmods.MODALIASES, root=root_dir, kver=kver
-                )
+                        if ret != 0 or not os.path.exists(mod_file):
+                            sys.stderr.write(
+                                "virtme: warning: depmod failed to generate "
+                                f"modules.dep for {kernel.moddir} (exit {ret}); "
+                                "module auto-detection may not work\n"
+                            )
+                    modfiles = modfinder.find_modules_from_install(
+                        virtmods.MODALIASES, root=mod_path, kver=kver
+                    )
+                    # Resolve out of mod_path before it's removed after `with` block
+                    kernel.modfiles = [os.path.realpath(path) for path in modfiles]
         kernel.dtb = None  # For now
     elif args.kdir is not None:
         kimg = os.path.join(args.kdir, arch.kimg_path())

--- a/virtme/modfinder.py
+++ b/virtme/modfinder.py
@@ -11,10 +11,13 @@ sort of hotplug.  Instead it generates a topological order and loads
 everything.  The idea is to require very few modules.
 """
 
+import contextlib
 import itertools
+import os
 import platform
 import re
 import subprocess
+import tempfile
 
 from . import util
 
@@ -67,3 +70,24 @@ def find_modules_from_install(aliases, root=None, kver=None, moddir=None):
     return merge_mods(
         resolve_dep(a, root=root, kver=kver, moddir=moddir) for a in aliases
     )
+
+
+@contextlib.contextmanager
+def get_mod_path(moddir, kver):
+    """
+    Context manager yielding a basedir suitable for `depmod -b <basedir>
+    <kver>` and `modprobe -d <basedir> -S <kver>` that resolves to
+    `moddir`, exposing it under both usr/lib/modules/<kver> and
+    lib/modules/<kver> since different kmod builds only search one or the
+    other.
+    """
+    if not kver or os.path.basename(kver) != kver or kver in (".", ".."):
+        raise ValueError(f"invalid kernel version: {kver!r}")
+
+    with tempfile.TemporaryDirectory(prefix="virtme-moddir-") as compat_root:
+        compat_moduledir = os.path.join(compat_root, "usr", "lib", "modules")
+        os.makedirs(compat_moduledir, exist_ok=True)
+        os.symlink(os.path.realpath(moddir), os.path.join(compat_moduledir, kver))
+        os.symlink(os.path.join("usr", "lib"), os.path.join(compat_root, "lib"))
+
+        yield compat_root


### PR DESCRIPTION
Some kmod/depmod builds (e.g. openSUSE's) hardcode the module search path
to <basedir>/usr/lib/modules/<kver> and never fall back to the classic
<basedir>/lib/modules/<kver> layout used by many downloaded kernel packages
(Debian/Ubuntu .debs, etc). Passing root_dir straight to 'depmod -b' and
'modprobe -d' therefore fails to find the already-resolved kernel.moddir on
such systems:

    depmod: ERROR: could not open directory <root>/usr/lib/modules/<kver>
    depmod: FATAL: could not search modules

Previous commit made this failure visible via a warning; this commit fixes
it. Add modfinder.get_mod_path(), which builds a small, disposable
directory containing usr/lib/modules/<kver> symlinked at the real module
directory, and use that as the basedir for both the depmod invocation and
find_modules_from_install()'s modprobe calls. This works regardless of
which layout convention the local kmod build expects, without needing to
guess or probe for it.

Verified against a downloaded Ubuntu mainline v6.6 kernel (modules shipped
at lib/modules/<kver>, no usr/ prefix) on a host whose depmod (openSUSE
kmod 34.2) only accepts usr/lib/modules/<kver>: virtiofs.ko is now found
and loaded from the initramfs, and

    ./vng -v -r v6.6 -- uname -r

boots and runs successfully end-to-end, where it previously panicked
at boot with:

    VFS: Cannot open root device "ROOTFS"
    Kernel panic - not syncing: VFS: Unable to mount root fs

Co-developed-by: Marcos Paulo de Souza <mpdesouza@suse.com>