### PR TITLE
run: Don't kill ssh-client session on a missing guest cwd

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1347,10 +1347,10 @@ def ssh_client(args):
 
     if cwd is not None:
         guest_cwd = "/" if cwd == "." else f"/{cwd}"
-        remote_cmd_str = f"cd -- {shlex.quote(guest_cwd)}" + (
-            f" && {args.remote_cmd}"
+        remote_cmd_str = f"cd -- {shlex.quote(guest_cwd)} ; " + (
+            f"{args.remote_cmd}"
             if args.remote_cmd is not None
-            else ' && exec "${SHELL:-/bin/sh}" -i'
+            else 'exec "${SHELL:-/bin/sh}" -i'
         )
         remote_cmd = [
             "--",


### PR DESCRIPTION
ssh_client() chained "cd DIR && exec $SHELL", so a directory that doesn't exist in the guest (e.g. host cwd not present under a --root-disk or a different root than assumed) aborted the whole shell instead of just failing the cd.