### PR TITLE
vng, run: Add --root-disk to boot from a disk image

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,46 @@ Examples
             ├─init.scope
    ```
 
+ - Run a kernel against a disk image instead of a host directory:
+   ```console
+   $ vng --run ./bzImage --root-disk ./tumbleweed.raw -- findmnt /
+   TARGET SOURCE   FSTYPE OPTIONS
+   /      /dev/vda ext4  ro,relatime
+   ```
+
+   `--root-disk` attaches the image to the guest over virtio-blk and lets the
+   kernel mount it as the root filesystem, the same way it would on real
+   hardware, instead of exporting a host directory over virtiofs or 9p. This
+   gives the guest a real block-backed root, which is what you want when the
+   code under test cares about the block layer, when the filesystem semantics
+   of virtiofs and 9p get in the way (mmap, hardlinks, file locking), or when
+   testing a foreign architecture, where virtiofs is often unavailable.
+
+   The kernel under test still comes from the host, and so do its modules and
+   the virtme-ng guest tools: they are exported read-only on mounts of their
+   own, so the image never needs to know anything about the kernel it boots.
+
+   The image is attached read-only unless `--rw` is given.
+
+   The kernel has to be able to reach the disk on its own, so it needs
+   `CONFIG_VIRTIO_BLK` and the filesystem of the image built in, along with
+   the virtio transports virtme-ng exports the guest tools over. Filesystems
+   are not part of the generic virtme-ng kernel configuration, so pick the one
+   matching your image:
+   ```console
+   $ vng --kconfig --configitem CONFIG_EXT4_FS=y
+   $ vng --build
+   ```
+
+ - Boot a partitioned disk image, such as a cloud image, by naming the
+   partition holding the root filesystem:
+   ```console
+   $ vng --run ./bzImage --root-disk ./cloud.qcow2 --root-dev /dev/vda3
+   ```
+
+   `--root-dev` accepts anything the kernel accepts in `root=`, so
+   `PARTUUID=<uuid>` and `PARTLABEL=<label>` work as well.
+
  - Run the current kernel creating a 1GB NUMA node with CPUs 0,1,3 assigned
    and a 3GB NUMA node with CPUs 2,4,5,6,7 assigned:
    ```console
@@ -764,7 +804,8 @@ Troubleshooting
 
  - If you're testing a kernel for an architecture different from the host, keep
    in mind that you need to use also `--root DIR` to use a specific chroot with
-   the binaries compatible with the architecture that you're testing.
+   the binaries compatible with the architecture that you're testing, or
+   `--root-disk IMAGE` to boot a disk image for that architecture.
 
    If the chroot doesn't exist in your system virtme-ng will automatically
    create it using the latest daily build Ubuntu cloud image:

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -110,8 +110,29 @@ def make_parser() -> "VirtmeArgumentParser":
     )
 
     g = parser.add_argument_group(title="Common guest options")
-    g.add_argument(
+    root = g.add_mutually_exclusive_group()
+    root.add_argument(
         "--root", action="store", default="/", help="Local path to use as guest root"
+    )
+    root.add_argument(
+        "--root-disk",
+        action="store",
+        default=None,
+        metavar="IMAGE",
+        help="Boot from a disk image attached over virtio-blk instead of "
+        "exporting a host directory as the guest root. The kernel must be "
+        "able to reach the disk on its own: CONFIG_VIRTIO_BLK, the "
+        "filesystem of the image and the virtio transports must all be "
+        "built in.",
+    )
+    g.add_argument(
+        "--root-dev",
+        action="store",
+        default=None,
+        metavar="DEVICE",
+        help="Guest device holding the root filesystem of --root-disk "
+        "(default: /dev/vda). Anything the kernel accepts in root= works "
+        "here, e.g. /dev/vda3 or PARTUUID=<uuid> for partitioned images.",
     )
     g.add_argument(
         "--systemd",
@@ -128,7 +149,7 @@ def make_parser() -> "VirtmeArgumentParser":
         action="store_true",
         help=(
             "Disable POSIX ACL support for external root virtiofs exports "
-            "(ignored with 9p or host root)"
+            "(ignored with 9p, host root, or --root-disk)"
         ),
     )
     g.add_argument(
@@ -742,7 +763,7 @@ def find_kernel_and_mods(arch, args) -> Kernel:
         if modmode == "none":
             pass
         elif modmode in ("use", "auto"):
-            if has_external_root(args):
+            if args.root != "/":
                 kernel.use_root_mods = True
                 kernel.moddir = f"{args.root}/usr/lib/modules/{kernel.version}"
                 if not os.path.exists(kernel.moddir):
@@ -1231,7 +1252,39 @@ def get_guest_relative_path(path, root):
 
 def has_external_root(args) -> bool:
     """Return True if the guest root is not the host root filesystem."""
-    return args.root != "/"
+    return args.root != "/" or args.root_disk is not None
+
+
+def detect_disk_format(path: str, verbose: bool = False) -> str:
+    """Return the QEMU image format of PATH, defaulting to raw."""
+    try:
+        out = subprocess.check_output(
+            ["qemu-img", "info", "--output=json", "--", path],
+            stderr=subprocess.DEVNULL,
+        )
+        return json.loads(out).get("format", "raw")
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        if verbose:
+            sys.stderr.write(
+                f"virtme: could not detect the format of {path} ({exc}), assuming raw\n"
+            )
+        return "raw"
+
+
+def export_root_disk(qemu, arch, qemuargs, args) -> None:
+    """Attach the --root-disk image as the first virtio-blk device."""
+    fmt = detect_disk_format(args.root_disk, verbose=args.verbose)
+    readonly = "" if args.rw else ",readonly=on"
+    qemuargs.extend(
+        [
+            "-drive",
+            f"if=none,id=virtme-root,"
+            f"file={qemu.quote_optarg(args.root_disk)},"
+            f"format={fmt}{readonly}",
+            "-device",
+            f"{arch.virtio_dev_type('blk')},drive=virtme-root",
+        ]
+    )
 
 
 def console_client(args):
@@ -1511,6 +1564,12 @@ def do_it() -> int:
             ssh_client(args)
         sys.exit(0)
 
+    if args.root_disk is not None and not os.path.exists(args.root_disk):
+        arg_fail(f"{args.root_disk} does not exist")
+
+    if args.root_dev is not None and args.root_disk is None:
+        arg_fail("--root-dev requires --root-disk")
+
     guest_cache_dir = None
     serial_getty_dir = None
     serial_getty_file = None
@@ -1547,6 +1606,15 @@ def do_it() -> int:
     config.modfiles = kernel.modfiles
     if config.modfiles:
         need_initramfs = True
+
+    if args.root_disk is not None and need_initramfs:
+        # An initramfs takes over the root mount from the kernel, and this one
+        # only knows how to mount a host export.
+        arg_fail(
+            "--root-disk needs a kernel that can reach the root device "
+            "without an initramfs: build CONFIG_VIRTIO_BLK, the filesystem of "
+            "the image and the virtio transports into it"
+        )
 
     if args.gdb is not None:
         if kernel.version:
@@ -1654,9 +1722,8 @@ def do_it() -> int:
     # Try to use virtio-fs first, in case of failure fallback to 9p, unless 9p
     # is forced.
     virtiofs_state = None
-    if args.force_9p:
-        use_virtiofs = False
-    else:
+    use_virtiofs = False
+    if not args.force_9p:
         # When --numa is used, the memory backend is already configured by the
         # user-provided NUMA layout.
         virtiofs_state = VirtioFSState(
@@ -1670,28 +1737,33 @@ def do_it() -> int:
             virt_arch = architectures.get("microvm")
         else:
             virt_arch = arch
-        virtiofs_config = VirtioFSConfig(
-            path=args.root,
-            mount_tag="ROOTFS",
-            rw=args.rw,
-            # Keep POSIX ACLs enabled by default for external roots, but let
-            # guests whose virtiofs client cannot negotiate ACLs opt out.
-            # When sharing the host root (/), --posix-acl breaks UID/GID
-            # translation which causes authentication failures.
-            posix_acl=(has_external_root(args) and not args.no_root_posix_acl),
-        )
-        use_virtiofs = export_virtiofs(
-            virt_arch,
-            qemuargs,
-            virtiofs_state,
-            virtiofs_config,
-            verbose=args.verbose,
-        )
+        if args.root_disk is None:
+            virtiofs_config = VirtioFSConfig(
+                path=args.root,
+                mount_tag="ROOTFS",
+                rw=args.rw,
+                # Keep POSIX ACLs enabled by default for external roots, but let
+                # guests whose virtiofs client cannot negotiate ACLs opt out.
+                # When sharing the host root (/), --posix-acl breaks UID/GID
+                # translation which causes authentication failures.
+                posix_acl=(has_external_root(args) and not args.no_root_posix_acl),
+            )
+            use_virtiofs = export_virtiofs(
+                virt_arch,
+                qemuargs,
+                virtiofs_state,
+                virtiofs_config,
+                verbose=args.verbose,
+            )
         if can_use_microvm(args) and use_virtiofs:
             if args.verbose:
                 sys.stderr.write("virtme: use 'microvm' QEMU architecture\n")
             arch = virt_arch
-    if not use_virtiofs:
+    if args.root_disk is not None:
+        # The guest root comes from a block device; there is no host directory
+        # to export. Guest tools and modules are exported separately below.
+        export_root_disk(qemu, arch, qemuargs, args)
+    elif not use_virtiofs:
         virtfs_config = VirtFSConfig(
             path=args.root,
             mount_tag="/dev/root",
@@ -1730,9 +1802,20 @@ def do_it() -> int:
         if not os.path.isfile(host_busybox):
             print(f"busybox {host_busybox} does not exist", file=sys.stderr)
             raise SilentError()
-        rel_busybox = get_guest_relative_path(host_busybox, args.root)
+        # A host path says nothing about the contents of a disk image, so
+        # always export busybox to disk-backed roots.
+        rel_busybox = (
+            None
+            if args.root_disk is not None
+            else get_guest_relative_path(host_busybox, args.root)
+        )
         if rel_busybox is not None:
             busybox_guest_path = os.path.join("/", rel_busybox)
+
+    # Guest path of the module directory of the kernel under test, when it is
+    # exported on a mount of its own instead of being reachable through the
+    # guest root.
+    module_link_path = None
 
     if not has_external_root(args):
         if args.systemd:
@@ -1796,6 +1879,41 @@ def do_it() -> int:
                 f"mount --bind {fstab_path} /etc/fstab",
             ]
         )
+        if args.root_disk is not None and kernel.moddir is not None:
+            # A disk image is unrelated to the kernel under test, so its
+            # modules cannot be reached through the guest root and need a
+            # mount of their own.
+            if args.kdir is not None and not kernel.use_root_mods:
+                # virtme-prep-kdir-mods fills kernel.moddir with symlinks
+                # pointing back into the kdir, which would dangle at the mount
+                # boundary, so export the whole kdir instead.
+                modules_path = args.kdir
+                module_link_path = os.path.join(
+                    "/run/virtme/modules", os.path.relpath(kernel.moddir, args.kdir)
+                )
+            else:
+                modules_path = kernel.moddir
+                module_link_path = "/run/virtme/modules"
+            modules_fstype = export_hostfs(
+                qemu,
+                arch,
+                qemuargs,
+                virtiofs_state,
+                path=modules_path,
+                mount_tag="virtme.modules",
+                verbose=args.verbose,
+            )
+            initsh.extend(
+                [
+                    "mkdir -p /run/virtme/modules",
+                    hostfs_mount_cmd(
+                        modules_fstype,
+                        "ro",
+                        "virtme.modules",
+                        "/run/virtme/modules",
+                    ),
+                ]
+            )
         if host_busybox is not None and busybox_guest_path is None:
             busybox_fstype = export_hostfs(
                 qemu,
@@ -1831,7 +1949,10 @@ def do_it() -> int:
         initcmds = ["init=/bin/sh", "--", "-c", "; ".join(initsh)]
 
     # Arrange for modules to end up in the right place
-    if kernel.moddir is not None:
+    if module_link_path is not None:
+        # Exported on a mount of their own, see above.
+        kernelargs.append(f"virtme_link_mods={qemu.quote_optarg(module_link_path)}")
+    elif kernel.moddir is not None:
         if kernel.use_root_mods:
             # Tell virtme-init to use the root /lib/modules
             kernelargs.append("virtme_root_mods=1")
@@ -2323,7 +2444,10 @@ def do_it() -> int:
     if os.geteuid() == 0 or (
         args.user == "root"
         and has_external_root(args)
-        and os.access(os.path.join(args.root, "root"), os.R_OK | os.W_OK | os.X_OK)
+        and (
+            args.root_disk is not None
+            or os.access(os.path.join(args.root, "root"), os.R_OK | os.W_OK | os.X_OK)
+        )
     ):
         kernelargs.append("virtme_root_user=1")
     if busybox_guest_path is not None:
@@ -2377,7 +2501,18 @@ def do_it() -> int:
         # No initramfs!  Warning: this is slower than using an initramfs
         # because the kernel will wait for device probing to finish.
         # Sigh.
-        if use_virtiofs:
+        if args.root_disk is not None:
+            # Let the kernel find, probe and mount the root device by itself,
+            # exactly like it would on real hardware. Without rootfstype= it
+            # tries every filesystem it has, and it lists the partitions it
+            # can see if none of them works out.
+            kernelargs.extend(
+                [
+                    f"root={qemu.quote_optarg(args.root_dev or '/dev/vda')}",
+                    "rootwait",
+                ]
+            )
+        elif use_virtiofs:
             kernelargs.extend(
                 [
                     "rootfstype=virtiofs",
@@ -2418,7 +2553,7 @@ def do_it() -> int:
     # sense to be used with --root, too), while the rest will have at least 2048.
     # This should be safe overall for the regular x86_64 args.root == / workflow,
     # otherwise this guard could be lifted in the future.
-    if has_external_root(args):
+    if has_external_root(args) and args.root_disk is None:
         projected_cmdline = " ".join(quote_karg(arg) for arg in kernelargs + initcmds)
         if len(projected_cmdline.encode("utf-8")) > KERNEL_CMDLINE_MAX:
             guest_initsh = create_guest_init_script(args.root, "; ".join(initsh))

--- a/virtme_ng/run.py
+++ b/virtme_ng/run.py
@@ -281,11 +281,32 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         help="Override the default user shell",
     )
 
-    parser.add_argument(
+    root = parser.add_mutually_exclusive_group()
+    root.add_argument(
         "--root",
         action="store",
         help="Pass a specific chroot to use inside the virtualized kernel "
         + "(useful with --arch)",
+    )
+
+    root.add_argument(
+        "--root-disk",
+        action="store",
+        metavar="IMAGE",
+        help="Boot from a disk image attached over virtio-blk, instead of "
+        + "exporting a host directory as the guest root (useful with "
+        + "--arch). The kernel must be able to reach the disk on its own: "
+        + "CONFIG_VIRTIO_BLK, the filesystem of the image and the virtio "
+        + "transports must all be built in.",
+    )
+
+    parser.add_argument(
+        "--root-dev",
+        action="store",
+        metavar="DEVICE",
+        help="Guest device holding the root filesystem of --root-disk "
+        + "(default: /dev/vda). Anything the kernel accepts in root= works "
+        + "here, e.g. /dev/vda3 or PARTUUID=<uuid> for partitioned images.",
     )
 
     parser.add_argument(
@@ -306,7 +327,7 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         action="store_true",
         help=(
             "Disable POSIX ACL support for external root virtiofs exports "
-            "(ignored with 9p or host root)"
+            "(ignored with 9p, host root, or --root-disk)"
         ),
     )
 
@@ -515,7 +536,8 @@ virtme-ng is based on virtme, written by Andy Lutomirski <luto@kernel.org>.
         "--arch",
         action="store",
         help="Generate and test a kernel for a specific architecture "
-        "(default is host architecture ; if set, to be used with --root)",
+        "(default is host architecture ; if set, to be used with --root "
+        "or --root-disk)",
     )
 
     parser.add_argument(
@@ -998,8 +1020,12 @@ class KernelSource:
                     f"available: {' '.join(ARCH_MAPPING)}",
                     show_usage=False,
                 )
-            if args.root is None and get_host_arch() != args.arch:
-                arg_fail("--arch used without --root")
+            if (
+                args.root is None
+                and args.root_disk is None
+                and get_host_arch() != args.arch
+            ):
+                arg_fail("--arch used without --root or --root-disk")
             if "max-cpus" in ARCH_MAPPING[args.arch]:
                 self.cpus = ARCH_MAPPING[args.arch]["max-cpus"]
             self.virtme_param["arch"] = "--arch " + ARCH_MAPPING[args.arch]["qemu_name"]
@@ -1017,6 +1043,18 @@ class KernelSource:
             self.virtme_param["root"] = f"--root {args.root}"
         else:
             self.virtme_param["root"] = ""
+
+    def _get_virtme_root_disk(self, args):
+        opts = []
+        if args.root_disk is not None:
+            if not os.path.exists(args.root_disk):
+                arg_fail(f"{args.root_disk} does not exist", show_usage=False)
+            opts.append(f"--root-disk {shlex.quote(args.root_disk)}")
+        elif args.root_dev is not None:
+            arg_fail("--root-dev requires --root-disk", show_usage=False)
+        if args.root_dev is not None:
+            opts.append(f"--root-dev {shlex.quote(args.root_dev)}")
+        self.virtme_param["root_disk"] = " ".join(opts)
 
     def _get_virtme_systemd(self, args):
         if args.systemd:
@@ -1039,7 +1077,9 @@ class KernelSource:
     def _get_virtme_cwd(self, args):
         if args.cwd is not None:
             self.virtme_param["cwd"] = "--cwd " + args.cwd
-        elif args.root is None or args.ssh_client is not None:
+        elif (
+            args.root is None and args.root_disk is None or args.ssh_client is not None
+        ):
             self.virtme_param["cwd"] = "--pwd"
         else:
             self.virtme_param["cwd"] = ""
@@ -1418,6 +1458,7 @@ class KernelSource:
         self._get_virtme_shell(args)
         self._get_virtme_arch(args)
         self._get_virtme_root(args)
+        self._get_virtme_root_disk(args)
         self._get_virtme_systemd(args)
         self._get_virtme_rw(args)
         self._get_virtme_no_root_posix_acl(args)
@@ -1474,6 +1515,7 @@ class KernelSource:
             + f"{self.virtme_param['shell']} "
             + f"{self.virtme_param['arch']} "
             + f"{self.virtme_param['root']} "
+            + f"{self.virtme_param['root_disk']} "
             + f"{self.virtme_param['systemd']} "
             + f"{self.virtme_param['rw']} "
             + f"{self.virtme_param['no_root_posix_acl']} "


### PR DESCRIPTION
vng always builds the guest root by exporting a host directory over virtiofs, falling back to 9p. That is the right default for kernel work on the host rootfs, but it is also the only option, and both transports have gaps that show up as soon as the guest userspace is doing something real: 9p has known POSIX shortcomings around hardlinks, locking and mmap, and virtiofs is frequently unavailable when testing a foreign architecture, which is precisely when an external root is needed. Neither exercises the block layer at all.

Add --root-disk IMAGE, mutually exclusive with --root, to attach a disk image over virtio-blk and use it as the guest root. It is an external root like --root DIR, so it reuses the same guest init one-liner; the difference is that the modules of the kernel under test can no longer be reached through the root, so they get a mount of their own next to the guest tools. The image therefore never has to know anything about the kernel it boots.

Finding, probing and mounting the root device is left entirely to the kernel: --root-disk sets root= and rootwait on the command line and stays out of the way. This is the path vng already takes for virtiofs and 9p roots when no initramfs is needed, and it means partition tables, absent rootfstype=, PARTUUID=/PARTLABEL= and asynchronous device probing are all handled by the kernel rather than reimplemented on the host. Nothing is added to the initramfs, and --root-dev names the device holding the root filesystem, defaulting to /dev/vda, for images that carry a partition table.

The kernel therefore has to be able to reach the disk by itself, which means CONFIG_VIRTIO_BLK, the filesystem of the image, and the virtio transports used for the guest tools, all built in. Refuse the combination otherwise rather than booting into an initramfs that only knows how to mount a host export.

---

Test it:
```
$ wget -P /tmp https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-kvm-and-xen.qcow2
$ cd $LINUX_GIT
$ git clean -fdx
$ vng --kconfig --configitem CONFIG_BTRFS_FS=y
$ vng -b
$ /mnt/ext/src/usr/virtme-ng/tmp/vng --root-disk /tmp/openSUSE-Tumbleweed-Minimal-VM.x86_64-kvm-and-xen.qcow2 --root-dev /dev/vda3
          _      _
   __   _(_)_ __| |_ _ __ ___   ___       _ __   __ _
   \ \ / / |  __| __|  _   _ \ / _ \_____|  _ \ / _  |
    \ V /| | |  | |_| | | | | |  __/_____| | | | (_| |
     \_/ |_|_|   \__|_| |_| |_|\___|     |_| |_|\__  |
                                                |___/
   kernel version: 7.2.0-virtme x86_64
   (CTRL+d to exit)

virtme-ng:/ # cat /etc/os-release
NAME="openSUSE Tumbleweed"
# VERSION="20260825"
ID="opensuse-tumbleweed"
ID_LIKE="opensuse suse"
VERSION_ID="20260825"
PRETTY_NAME="openSUSE Tumbleweed"
ANSI_COLOR="0;32"
# CPE 2.3 format, boo#1217921
CPE_NAME="cpe:2.3:o:opensuse:tumbleweed:20260825:*:*:*:*:*:*:*"
#CPE 2.2 format
#CPE_NAME="cpe:/o:opensuse:tumbleweed:20260825"
BUG_REPORT_URL="https://bugzilla.opensuse.org"
SUPPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Tumbleweed"
LOGO="distributor-logo-Tumbleweed"

virtme-ng:/ # findmnt /
TARGET SOURCE                              FSTYPE OPTIONS
/      /dev/vda3[/@/.snapshots/1/snapshot] btrfs  ro,relatime,discard=async,noacl,space_cache=v2,subvolid=258,subvol=/@/.snapshots/1/snapshot
```
