### PR TITLE
run: qemu: Use -object monitor-hmp instead of deprecated -mon

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1964,7 +1964,10 @@ def do_it() -> int:
         )
         qemuargs.extend(["-serial", "chardev:console"])
         if not args.disable_monitor:
-            qemuargs.extend(["-mon", "chardev=console"])
+            if qemu.has_monitor_object:
+                qemuargs.extend(["-object", "monitor-hmp,id=monitor,chardev=console"])
+            else:
+                qemuargs.extend(["-mon", "chardev=console"])
 
     if not args.video and not args.script_sh and not args.script_exec:
         if args.nvgpu is None:

--- a/virtme/qemu_helpers.py
+++ b/virtme/qemu_helpers.py
@@ -20,6 +20,7 @@ class Qemu:
         self.arch = arch
         self.has_multidevs = None
         self.cannot_overmount_virtfs = None
+        self.has_monitor_object = None
 
         if not qemubin:
             qemubin = shutil.which(f"qemu-system-{arch}")
@@ -49,6 +50,14 @@ class Qemu:
             self.has_multidevs = (
                 re.search(r"version (?:1\.|2\.|3\.|4\.[01][^\d])", self.version) is None
             )
+
+            # QEMU 11.1+ supports -object monitor-hmp/monitor-qmp as
+            # replacement for the deprecated -mon option
+            match = re.search(r"version (\d+)\.(\d+)", self.version)
+            self.has_monitor_object = match is not None and (
+                int(match.group(1)),
+                int(match.group(2)),
+            ) >= (11, 1)
 
     def quote_optarg(self, a: str) -> str:
         """Quote an argument to an option."""


### PR DESCRIPTION
QEMU 11.1 converted the monitor objects to QOM and deprecated the -mon option in favor of -object with monitor-hmp or monitor-qmp types.

Using -mon produces the following warning on recent QEMU:
```
 qemu-system-x86_64: -mon chardev=console: warning: '-mon' is deprecated,
 use '-object' with 'monitor-hmp' or 'monitor-qmp' types instead
```
Switch to the new -object monitor-hmp syntax when running QEMU >= 11.1 and keep the old -mon syntax as a fallback for older QEMU versions that don't support the monitor-hmp object type yet.

Note that -object requires an explicit id, unlike -mon, so the monitor object is created with id=monitor.