### PR TITLE
vng -g fixes

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -1921,7 +1921,11 @@ def do_it() -> int:
 
     kernelargs.extend(["virtme_console=" + arg for arg in arch.serial_console_args()])
 
-    if not args.script_sh and not args.script_exec:
+    # Do not break old syntax "-g command"
+    if args.graphics is not None and args.script_sh is None:
+        args.script_sh = args.graphics
+
+    if args.script_sh is None and args.script_exec is None:
         qemuargs.extend(["-echr", "1"])
 
         if args.systemd:
@@ -1966,7 +1970,7 @@ def do_it() -> int:
         if not args.disable_monitor:
             qemuargs.extend(["-mon", "chardev=console"])
 
-    if not args.video and not args.script_sh and not args.script_exec:
+    if not args.video and args.script_sh is None and args.script_exec is None:
         if args.nvgpu is None:
             qemuargs.extend(arch.qemu_nodisplay_args())
         else:
@@ -2194,10 +2198,6 @@ def do_it() -> int:
 
         # Ask virtme-init to run the script
         kernelargs.append(f"virtme.exec=`{shellcmd}`")
-
-    # Do not break old syntax "-g command"
-    if args.graphics is not None and args.script_sh is None:
-        args.script_sh = args.graphics
 
     if args.script_sh is not None:
         _, ret_path = tempfile.mkstemp(prefix="virtme_ret")

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -709,7 +709,7 @@ run_user_gui() {
     fi
 
     # Clean up any previous X11 state.
-    rm -f /tmp/.X11*/* /tmp/.X11-lock
+    rm -f /tmp/.X11*/* /tmp/.X*-lock
 
     # Create a .xinitrc to start the requested graphical application.
     xinit_rc=/run/tmp/.xinitrc

--- a/virtme_ng_init/src/main.rs
+++ b/virtme_ng_init/src/main.rs
@@ -1143,7 +1143,7 @@ fn run_user_gui(tty_fd: libc::c_int) {
         utils::run_cmd("/bin/sh", &["-c", &format!("chown {user} /dev/char/*")]);
 
         // Clean up any previous X11 state.
-        utils::run_cmd("/bin/sh", &["-c", "rm -f /tmp/.X11*/* /tmp/.X11-lock"]);
+        utils::run_cmd("/bin/sh", &["-c", "rm -f /tmp/.X11*/* /tmp/.X*-lock"]);
 
         // Start xinit directly.
         storage = format!("su -c 'xinit /run/tmp/.xinitrc' -- {user}");


### PR DESCRIPTION
Two independent bugs, both of which break `vng -g`.
- Duplicate console chardev, a bare `-g` (no command) never gets past QEMU
- Missing X11 lock file cleanup: Xorg in the guest fails whenever the host runs an X server on `:0` owned by another user (e.g., a display manager greeter)